### PR TITLE
Redesign study dashboard layout and header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,24 @@
 import React, { useState, useEffect } from 'react';
-import { PlusCircle, BarChart3, Eye } from 'lucide-react';
+import {
+  PlusCircle,
+  Eye,
+  Clock,
+  Activity,
+  Target,
+  Percent,
+  Upload,
+  CalendarClock,
+  AlertTriangle,
+  CalendarDays,
+  ChevronRight
+} from 'lucide-react';
 
 // Importar componentes
 import { ProfileModal, SubjectModal, ItemDetailsModal, SyllabusModal, ProgressReportModal, SessionHistoryModal } from './components/Modals';
 import { SessionModal } from './components/SessionModal';
 import { SubjectsOverview } from './components/SubjectsOverview';
 import { SubjectsManagement } from './components/SubjectsManagement';
-import { AppHeader, ProfileSection } from './components/Header';
+import { AppHeader } from './components/Header';
 import { Calendar } from './components/Calendar';
 import ContestComparison from './components/ContestComparison';
 import { fetchGlobalEditais } from './services/globalEditaisService';
@@ -30,7 +42,6 @@ function App() {
   const [selectedSyllabusItem, setSelectedSyllabusItem] = useState(null);
   const [isItemDetailsModalOpen, setIsItemDetailsModalOpen] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('Carregando dados...');
-  const [currentView, setCurrentView] = useState('overview'); // 'overview', 'subjects', 'calendar', 'reports'
 
   const [studyProfiles, setStudyProfiles] = useState([]);
   const [activeProfileId, setActiveProfileId] = useState(null);
@@ -377,68 +388,16 @@ function App() {
 
   // Componente de Loading
   const LoadingSpinner = () => (
-    <div className="loading-container">
+    <div className="loading-state">
       <div className="loading-spinner" />
-      <p className="loading-message">{loadingMessage}</p>
-      <div className="loading-progress">
-        <div className="loading-bar"></div>
+      <div className="loading-copy">
+        <p className="loading-message">{loadingMessage}</p>
+        <p className="loading-subtext">Preparando seu ambiente de estudos personalizado...</p>
       </div>
     </div>
   );
 
   // Componente de Breadcrumb
-  const Breadcrumb = () => {
-    const activeProfile = studyProfiles.find(p => p.id === activeProfileId);
-    const viewNames = {
-      overview: 'Visão Geral',
-      subjects: 'Matérias',
-      calendar: 'Calendário',
-      reports: 'Relatórios'
-    };
-
-    return (
-      <div className="breadcrumb">
-        <span className="breadcrumb-item">
-          📚 {activeProfile?.name || 'Nenhum Concurso'}
-        </span>
-        <span className="breadcrumb-separator">›</span>
-        <span className="breadcrumb-item active">
-          {viewNames[currentView]}
-        </span>
-      </div>
-    );
-  };
-
-  // Componente de Estatísticas Rápidas
-  const QuickStats = () => {
-    const totalSubjects = activeSubjects.length;
-    const totalItems = activeSyllabusItems.length;
-    const studiedItems = activeSyllabusItems.filter(item => item.isStudied).length;
-    const studiedPercentage = totalItems > 0 ? ((studiedItems / totalItems) * 100).toFixed(0) : 0;
-    const totalHours = activeSessions.reduce((sum, session) => sum + session.duration, 0);
-
-    return (
-      <div className="quick-stats">
-        <div className="stat-item">
-          <span className="stat-value">{totalSubjects}</span>
-          <span className="stat-label">Matérias</span>
-        </div>
-        <div className="stat-item">
-          <span className="stat-value">{studiedPercentage}%</span>
-          <span className="stat-label">Progresso</span>
-        </div>
-        <div className="stat-item">
-          <span className="stat-value">{totalHours.toFixed(1)}h</span>
-          <span className="stat-label">Estudadas</span>
-        </div>
-        <div className="stat-item">
-          <span className="stat-value">{studiedItems}/{totalItems}</span>
-          <span className="stat-label">Itens</span>
-        </div>
-      </div>
-    );
-  };
-
   // Componente de Toast Melhorado
   const Toast = ({ message, type, isVisible }) => {
     if (!isVisible) return null;
@@ -622,203 +581,453 @@ function App() {
   const activeSubjects = subjects.filter(subject => subject.profileId === activeProfileId);
   const activeSessions = studySessions.filter(session => session.profileId === activeProfileId);
   const activeSimulados = simulados.filter(s => s.profileId === activeProfileId);
-  const activeSyllabusItems = syllabusItems.filter(item => 
+  const activeSyllabusItems = syllabusItems.filter(item =>
     activeSubjects.some(subject => subject.id === item.subjectId)
   );
+
+  const activeProfile = studyProfiles.find(profile => profile.id === activeProfileId);
+  const subjectLookup = new Map(activeSubjects.map(subject => [subject.id, subject]));
+  const todayISO = new Date().toISOString().split('T')[0];
+
+  const formatDateLabel = (dateString) => {
+    if (!dateString) return '-';
+    const parsed = new Date(dateString);
+    if (Number.isNaN(parsed.getTime())) return '-';
+    return parsed.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+  };
+
+  const formatDuration = (minutes) => {
+    if (!minutes) return '0h';
+    const hours = minutes / 60;
+    if (hours >= 1) {
+      return `${hours.toFixed(1)}h`;
+    }
+    return `${Math.round(minutes)}min`;
+  };
+
+  const getSubjectLabel = (subjectId) => subjectLookup.get(subjectId)?.name || 'Sem matéria';
+
+  const totalHoursStudied = activeSessions.reduce((sum, session) => sum + (session.duration || 0), 0) / 60;
+  const totalItems = activeSyllabusItems.length;
+  const studiedItems = activeSyllabusItems.filter(item => item.isStudied).length;
+  const studiedPercentage = totalItems > 0 ? (studiedItems / totalItems) * 100 : 0;
+  const nextReviewLabel = getNextReviewDate();
+
+  const overviewStats = [
+    {
+      label: 'Horas estudadas',
+      value: `${totalHoursStudied.toFixed(1)}h`,
+      description: 'Tempo total dedicado ao concurso atual.',
+      icon: Clock
+    },
+    {
+      label: 'Sessões registradas',
+      value: activeSessions.length,
+      description: 'Sprints de estudo concluídos.',
+      icon: Activity
+    },
+    {
+      label: 'Simulados feitos',
+      value: activeSimulados.length,
+      description: 'Simulados cadastrados para este concurso.',
+      icon: Target
+    },
+    {
+      label: 'Progresso do edital',
+      value: `${Math.round(studiedPercentage)}%`,
+      description: `${studiedItems}/${totalItems || 0} itens concluídos.`,
+      icon: Percent
+    },
+    {
+      label: 'Próxima revisão',
+      value: nextReviewLabel,
+      description: 'Data sugerida conforme seu ciclo de revisões.',
+      icon: CalendarClock
+    }
+  ];
+
+  const urgentReviewItems = getUrgentReviews().slice(0, 5);
+  const upcomingSessions = [...activeSessions]
+    .filter(session => session.date && session.date >= todayISO)
+    .sort((a, b) => new Date(a.date) - new Date(b.date))
+    .slice(0, 4);
+  const upcomingSimulados = [...activeSimulados]
+    .filter(simulado => simulado.data)
+    .sort((a, b) => new Date(a.data) - new Date(b.data))
+    .slice(0, 3);
 
   // Renderização condicional baseada no estado de carregamento
   if (isLoading) {
     return (
-      <div className="app-container">
-        <LoadingSpinner />
+      <div className="app-shell">
+        <div className="app-shell__gradient" />
+        <div className="app-shell__grid" />
+        <div className="app-shell__blur app-shell__blur--1" />
+        <div className="app-shell__blur app-shell__blur--2" />
+        <div className="app-shell__content flex items-center justify-center">
+          <div className="card w-full max-w-md p-10 text-center">
+            <LoadingSpinner />
+          </div>
+        </div>
       </div>
     );
   }
 
   // Interface principal
   return (
-    <div className="app-container mx-auto" style={{maxWidth:'1400px', padding:'0 1rem'}}>
-      {/* Header */}
-      <AppHeader
-        setIsProgressReportModalOpen={setIsProgressReportModalOpen}
-        handleExportData={handleExportData}
-        handleImportData={handleImportData}
-        studyProfiles={studyProfiles}
-        activeProfileId={activeProfileId}
-        setActiveProfileId={handleSetActiveProfile}
-        onOpenProfileModal={() => setIsProfileModalOpen(true)}
-      />
+    <>
+      <div className="app-shell">
+        <div className="app-shell__gradient" />
+        <div className="app-shell__grid" />
+        <div className="app-shell__blur app-shell__blur--1" />
+        <div className="app-shell__blur app-shell__blur--2" />
+        <div className="app-shell__content space-y-8">
+        <AppHeader
+          setIsProgressReportModalOpen={setIsProgressReportModalOpen}
+          handleExportData={handleExportData}
+          handleImportData={handleImportData}
+          studyProfiles={studyProfiles}
+          activeProfileId={activeProfileId}
+          setActiveProfileId={handleSetActiveProfile}
+          onOpenProfileModal={() => setIsProfileModalOpen(true)}
+        />
 
-      {/* Breadcrumb e Estatísticas */}
-      {activeProfileId && (
-        <div className="navigation-section">
-          <Breadcrumb />
-          <QuickStats />
-        </div>
-      )}
-
-      {/* Conteúdo Principal */}
-      {!activeProfileId ? (
-        <div className="card">
-          <div className="welcome-section">
-            <h2>Bem-vindo ao Organizador de Estudos!</h2>
-            <p>Crie ou selecione um perfil de concurso para começar a organizar seus estudos.</p>
-            <button
-              className="btn btn-primary"
-              onClick={() => setIsProfileModalOpen(true)}
-            >
-              <PlusCircle size={20} />
-              Criar Primeiro Perfil
-            </button>
+        {!activeProfileId ? (
+          <div className="card space-y-4 p-10 text-center">
+            <h2 className="text-2xl font-semibold text-white">Comece seu planejamento</h2>
+            <p className="text-sm text-slate-300">
+              Crie um concurso para visualizar estatísticas, metas e revisões em um único painel.
+            </p>
+            <div className="flex justify-center">
+              <button
+                className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-5 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                onClick={() => setIsProfileModalOpen(true)}
+              >
+                <PlusCircle size={18} />
+                Criar primeiro concurso
+              </button>
+            </div>
           </div>
-        </div>
-      ) : (
-        <div className="space-y-6" style={{ maxWidth: '1150px', margin: '0 auto' }}>
-          {/* Estatísticas Rápidas */}
-          <div className="card">
-            <h2>
-              <BarChart3 size={20} />
-              Estatísticas Rápidas
-            </h2>
-            <div className="stats-grid">
-              <div className="stat-card">
-                <div className="stat-value">{(activeSessions.reduce((total, session) => total + (session.duration || 0), 0) / 60).toFixed(1)}h</div>
-                <div className="stat-label">Total Estudado</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">{activeSessions.length}</div>
-                <div className="stat-label">Sessões</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">{activeSimulados.length}</div>
-                <div className="stat-label">Simulados</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">
-                  {activeSyllabusItems.length > 0
-                    ? (activeSyllabusItems.reduce((sum, item) => sum + (item.accuracy || 0), 0) / activeSyllabusItems.length).toFixed(0)
-                    : 0}%
+        ) : (
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+            <section className="space-y-6">
+              <div className="card space-y-6 p-6 sm:p-8">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <span className="text-xs uppercase tracking-[0.35em] text-sky-100/70">Visão geral</span>
+                    <h2 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">
+                      {activeProfile?.name || 'Seu concurso'}
+                    </h2>
+                    <p className="mt-3 text-sm text-slate-300">
+                      {activeProfile?.description
+                        ? activeProfile.description
+                        : 'Acompanhe horas estudadas, simulados e revisões em um único lugar.'}
+                    </p>
+                  </div>
+                  {activeProfile?.examDate && (
+                    <div className="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-right">
+                      <span className="text-xs uppercase tracking-wide text-slate-400">Data da prova</span>
+                      <p className="mt-2 text-lg font-semibold text-white">
+                        {new Date(activeProfile.examDate).toLocaleDateString('pt-BR')}
+                      </p>
+                    </div>
+                  )}
                 </div>
-                <div className="stat-label">Média de Acerto Geral</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">{getNextReviewDate()}</div>
-                <div className="stat-label">Próxima Revisão Urgente</div>
-              </div>
-            </div>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button className="btn btn-primary" onClick={() => { setIsSimuladoModalOpen(true); }}>Registrar Simulado</button>
-              {globalEditais.length > 0 && activeSubjects.length > 0 && (
-                <button className="btn btn-secondary" onClick={() => setIsImportEditalOpen(true)}>Importar Itens de Edital</button>
-              )}
-            </div>
 
-            {/* Ciclo de Estudos Visual */}
-            {activeSubjects.length > 0 && (
-              <div className="study-cycle-indicator">
-                <div className="study-cycle-header">
-                  <span className="study-cycle-icon">🔄</span>
-                  <span className="study-cycle-title">Ciclo de Estudos Visual</span>
-                </div>
-                <div className="study-cycle-subjects">
-                  {activeSubjects.map(subject => (
-                    <div
-                      key={subject.id}
-                      className="study-cycle-item"
-                      style={{
-                        backgroundColor: subject.color + '20',
-                        borderLeft: `3px solid ${subject.color}`
-                      }}
-                    >
-                      <span className="cycle-subject-name">{subject.name}</span>
-                      <span className="cycle-subject-weight">Peso: {subject.weight || 1}</span>
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+                  {overviewStats.map(({ label, value, description, icon: Icon }) => (
+                    <div key={label} className="stat-card modern-stat">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-slate-400">{label}</p>
+                          <p className="mt-2 text-xl font-semibold text-white">{value}</p>
+                        </div>
+                        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/5 text-sky-200">
+                          <Icon size={18} />
+                        </div>
+                      </div>
+                      <p className="mt-3 text-xs text-slate-400">{description}</p>
                     </div>
                   ))}
                 </div>
-              </div>
-            )}
-          </div>
 
-          {activeSubjects.length === 0 ? (
-            <div className="card">
-              <div className="welcome-section">
-                <h2>Nenhuma matéria cadastrada</h2>
-                <p>Adicione sua primeira matéria para começar a organizar seus estudos.</p>
-                <button
-                  className="btn btn-primary"
-                  onClick={() => setIsSubjectModalOpen(true)}
-                >
-                  <PlusCircle size={20} />
-                  Adicionar Primeira Matéria
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-6">
-              {/* Calendário de Estudos */}
-              <div className="card">
-                <Calendar
-                  studySessions={activeSessions}
-                  syllabusItems={activeSyllabusItems}
-                  onDateClick={(date) => {
-                    // Aqui pode abrir um modal com detalhes do dia
-                  }}
-                />
-              </div>
-
-              {/* Matérias (Gerenciamento) */}
-              <SubjectsManagement
-                subjects={activeSubjects}
-                studySessions={activeSessions}
-                setIsSubjectModalOpen={setIsSubjectModalOpen}
-                setCurrentSubjectForSession={setCurrentSubjectForSession}
-                setIsSessionModalOpen={setIsSessionModalOpen}
-                setCurrentSubjectForSyllabus={setCurrentSubjectForSyllabus}
-                setIsSyllabusModalOpen={setIsSyllabusModalOpen}
-                setEditingSubject={setEditingSubject}
-                setConfirmationDialog={setConfirmationDialog}
-                handleDeleteSubject={handleDeleteSubject}
-                getSubjectStudyTime={getSubjectStudyTime}
-                calculateSubjectProgress={calculateSubjectProgress}
-                setIsSessionHistoryModalOpen={setIsSessionHistoryModalOpen}
-                setSelectedSubjectForHistory={setSelectedSubjectForHistory}
-              />
-
-              {/* Visão Geral das Matérias e Edital */}
-              <div className="card">
-                <h2>
-                  <Eye size={20} />
-                  Visão Geral das Matérias e Edital
-                </h2>
-                <SubjectsOverview
-                  subjects={activeSubjects}
-                  syllabusItems={activeSyllabusItems}
-                  setSyllabusItems={setSyllabusItems}
-                  expandedSubjects={expandedSubjects}
-                  setExpandedSubjects={setExpandedSubjects}
-                  getSubjectStudyTime={getSubjectStudyTime}
-                  setSelectedSyllabusItem={setSelectedSyllabusItem}
-                  setIsItemDetailsModalOpen={setIsItemDetailsModalOpen}
-                  studySessions={activeSessions}
-                />
-              </div>
-              <GlobalConcursosCard concursos={concursosGlobais} syllabusItems={syllabusItems} onImport={(id) => { setIsImportConcursoOpen(true); setSelectedConcursoForImport(id); }} />
-              {concursosGlobais.length > 1 && (
-                <div className="card">
-                  <h2>
-                    <Eye size={20} />
-                    Comparação de Editais (Concursos Globais)
-                  </h2>
-                  <ContestComparison concursos={concursosGlobais} />
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                    onClick={() => {
+                      setEditingSession(null);
+                      setCurrentSubjectForSession(null);
+                      setInitialSessionData(null);
+                      setIsSessionModalOpen(true);
+                    }}
+                  >
+                    <CalendarDays size={16} />
+                    Registrar sessão
+                  </button>
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                    onClick={() => setIsSubjectModalOpen(true)}
+                  >
+                    <PlusCircle size={16} />
+                    Nova matéria
+                  </button>
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                    onClick={() => setIsSimuladoModalOpen(true)}
+                  >
+                    <Target size={16} />
+                    Registrar simulado
+                  </button>
+                  {globalEditais.length > 0 && activeSubjects.length > 0 && (
+                    <button
+                      className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                      onClick={() => setIsImportEditalOpen(true)}
+                    >
+                      <Upload size={16} />
+                      Importar edital
+                    </button>
+                  )}
                 </div>
+
+                {activeSubjects.length > 0 && (
+                  <div className="study-cycle-indicator">
+                    <div className="study-cycle-header">
+                      <span className="study-cycle-icon">🔄</span>
+                      <span className="study-cycle-title">Distribuição do ciclo de estudos</span>
+                    </div>
+                    <div className="study-cycle-subjects">
+                      {activeSubjects.map(subject => (
+                        <div
+                          key={subject.id}
+                          className="study-cycle-item"
+                          style={{
+                            backgroundColor: `${subject.color || '#38bdf8'}20`,
+                            borderLeft: `3px solid ${subject.color || '#38bdf8'}`
+                          }}
+                        >
+                          <span className="cycle-subject-name">{subject.name}</span>
+                          <span className="cycle-subject-weight">Peso: {subject.weight || 1}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {activeSubjects.length === 0 ? (
+                <div className="card space-y-4 p-10 text-center">
+                  <h3 className="text-xl font-semibold text-white">Nenhuma matéria cadastrada</h3>
+                  <p className="text-sm text-slate-300">Adicione sua primeira matéria para liberar o ciclo de estudos.</p>
+                  <div className="flex justify-center">
+                    <button
+                      className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-5 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                      onClick={() => setIsSubjectModalOpen(true)}
+                    >
+                      <PlusCircle size={16} />
+                      Adicionar matéria
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="card p-6 sm:p-8">
+                    <Calendar
+                      studySessions={activeSessions}
+                      syllabusItems={activeSyllabusItems}
+                      onDateClick={() => {}}
+                    />
+                  </div>
+
+                  <SubjectsManagement
+                    subjects={activeSubjects}
+                    studySessions={activeSessions}
+                    setIsSubjectModalOpen={setIsSubjectModalOpen}
+                    setCurrentSubjectForSession={setCurrentSubjectForSession}
+                    setIsSessionModalOpen={setIsSessionModalOpen}
+                    setCurrentSubjectForSyllabus={setCurrentSubjectForSyllabus}
+                    setIsSyllabusModalOpen={setIsSyllabusModalOpen}
+                    setEditingSubject={setEditingSubject}
+                    setConfirmationDialog={setConfirmationDialog}
+                    handleDeleteSubject={handleDeleteSubject}
+                    getSubjectStudyTime={getSubjectStudyTime}
+                    calculateSubjectProgress={calculateSubjectProgress}
+                    setIsSessionHistoryModalOpen={setIsSessionHistoryModalOpen}
+                    setSelectedSubjectForHistory={setSelectedSubjectForHistory}
+                  />
+
+                  <div className="card space-y-6 p-6 sm:p-8">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                      <div>
+                        <span className="text-xs uppercase tracking-[0.3em] text-slate-300">Edital</span>
+                        <h2 className="mt-1 text-xl font-semibold text-white">Visão geral das matérias</h2>
+                      </div>
+                      <span className="text-xs uppercase tracking-wide text-slate-400">
+                        {studiedItems}/{totalItems || 0} itens mapeados
+                      </span>
+                    </div>
+                    <SubjectsOverview
+                      subjects={activeSubjects}
+                      syllabusItems={activeSyllabusItems}
+                      setSyllabusItems={setSyllabusItems}
+                      expandedSubjects={expandedSubjects}
+                      setExpandedSubjects={setExpandedSubjects}
+                      getSubjectStudyTime={getSubjectStudyTime}
+                      setSelectedSyllabusItem={setSelectedSyllabusItem}
+                      setIsItemDetailsModalOpen={setIsItemDetailsModalOpen}
+                      studySessions={activeSessions}
+                    />
+                  </div>
+
+                  <GlobalConcursosCard
+                    concursos={concursosGlobais}
+                    syllabusItems={syllabusItems}
+                    onImport={(id) => {
+                      setIsImportConcursoOpen(true);
+                      setSelectedConcursoForImport(id);
+                    }}
+                  />
+
+                  {concursosGlobais.length > 1 && (
+                    <div className="card space-y-4 p-6 sm:p-8">
+                      <div className="flex items-center gap-2 text-slate-300">
+                        <Eye size={18} />
+                        <h3 className="text-lg font-semibold text-white">Comparação de editais</h3>
+                      </div>
+                      <ContestComparison concursos={concursosGlobais} />
+                    </div>
+                  )}
+                </>
               )}
-            </div>
-          )}
-        </div>
-      )}
+            </section>
+
+            <aside className="space-y-6">
+              <div className="card space-y-4 p-6">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-amber-200/80">Prioridades</span>
+                    <h3 className="mt-1 text-lg font-semibold text-white">Revisões urgentes</h3>
+                  </div>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/40 bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-200">
+                    <AlertTriangle size={14} />
+                    {urgentReviewItems.length}
+                  </span>
+                </div>
+                <div className="space-y-3">
+                  {urgentReviewItems.length > 0 ? (
+                    urgentReviewItems.map(item => (
+                      <div
+                        key={item.id}
+                        className="flex items-start justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-3 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-white">{item.name}</p>
+                          <p className="text-xs text-slate-400">{getSubjectLabel(item.subjectId)}</p>
+                        </div>
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-1 text-xs font-semibold text-amber-200">
+                          <CalendarClock size={12} />
+                          {formatDateLabel(item.nextReviewDate)}
+                        </span>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="rounded-xl border border-white/5 bg-white/5 px-3 py-4 text-sm text-slate-300">
+                      Nenhuma revisão urgente no momento. Continue avançando! ✨
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="card space-y-4 p-6">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-sky-200/80">Planejamento</span>
+                    <h3 className="mt-1 text-lg font-semibold text-white">Próximas sessões</h3>
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  {upcomingSessions.length > 0 ? (
+                    upcomingSessions.map(session => (
+                      <div
+                        key={session.id}
+                        className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-3 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-white">{getSubjectLabel(session.subjectId)}</p>
+                          <p className="text-xs text-slate-400">
+                            {formatDateLabel(session.date)} • {formatDuration(session.duration)}
+                          </p>
+                          {session.topics && (
+                            <p className="mt-1 text-xs text-slate-500">{session.topics}</p>
+                          )}
+                        </div>
+                        <ChevronRight size={16} className="text-slate-500" />
+                      </div>
+                    ))
+                  ) : (
+                    <div className="rounded-xl border border-white/5 bg-white/5 px-3 py-4 text-sm text-slate-300">
+                      Nenhuma sessão futura registrada.
+                      <button
+                        className="mt-3 inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                        onClick={() => {
+                          setEditingSession(null);
+                          setCurrentSubjectForSession(null);
+                          setInitialSessionData(null);
+                          setIsSessionModalOpen(true);
+                        }}
+                      >
+                        <CalendarDays size={14} />
+                        Planejar agora
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="card space-y-4 p-6">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-slate-300">Preparação</span>
+                    <h3 className="mt-1 text-lg font-semibold text-white">Próximos simulados</h3>
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  {upcomingSimulados.length > 0 ? (
+                    upcomingSimulados.map(simulado => (
+                      <div key={simulado.id} className="rounded-xl border border-white/10 bg-white/5 p-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-white">{formatDateLabel(simulado.data)}</p>
+                            <p className="text-xs text-slate-400 capitalize">{simulado.tipo || 'Simulado'}</p>
+                          </div>
+                          <Target size={18} className="text-sky-200" />
+                        </div>
+                        {simulado.notaFinal !== undefined && simulado.notaFinal !== null && (
+                          <p className="mt-2 text-xs text-slate-300">Nota final: {simulado.notaFinal}</p>
+                        )}
+                      </div>
+                    ))
+                  ) : (
+                    <div className="rounded-xl border border-white/5 bg-white/5 px-3 py-4 text-sm text-slate-300">
+                      Nenhum simulado agendado.
+                      <button
+                        className="mt-3 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/10"
+                        onClick={() => setIsSimuladoModalOpen(true)}
+                      >
+                        <Target size={14} />
+                        Criar simulado
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </aside>
+          </div>
+        )}
+      </div>
+      </div>
 
       {/* Modais */}
-      <ProfileModal 
+      <ProfileModal
         isOpen={isProfileModalOpen}
         onClose={() => {
           setIsProfileModalOpen(false);
@@ -966,7 +1175,7 @@ function App() {
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,108 +2,13 @@ import React from 'react';
 import {
   Users,
   PlusCircle,
-  Edit2,
-  Trash2,
   BarChart3,
   Download,
   Upload,
   BookOpen,
-  Edit,
-  Plus
+  Sparkles,
+  CalendarDays
 } from 'lucide-react';
-
-export const ProfileSection = ({ 
-  studyProfiles,
-  activeProfileId,
-  setActiveProfileId,
-  setIsProfileModalOpen,
-  setEditingProfile,
-  setConfirmationDialog,
-  handleDeleteProfile
-}) => {
-  return (
-    <div className="profile-section">
-      <div className="profile-header">
-        <div className="profile-title">
-          <Users size={20} />
-          <span>Perfis de Concurso</span>
-        </div>
-        <button
-          className="btn btn-primary btn-sm"
-          onClick={() => setIsProfileModalOpen(true)}
-        >
-          <PlusCircle size={14} />
-          Novo Perfil
-        </button>
-      </div>
-
-      {studyProfiles.length === 0 ? (
-        <div className="profile-empty">
-          <span>Nenhum perfil criado.</span>
-          <button
-            className="btn btn-primary btn-sm"
-            onClick={() => setIsProfileModalOpen(true)}
-          >
-            Criar Primeiro Perfil
-          </button>
-        </div>
-      ) : (
-        <div className="profile-content">
-          <div className="profile-selector">
-            <label>Concurso Ativo:</label>
-            <select
-              value={activeProfileId || ''}
-              onChange={(e) => setActiveProfileId(e.target.value)}
-              className="profile-dropdown"
-            >
-              <option value="">Selecione um perfil</option>
-              {studyProfiles.map(profile => (
-                <option key={profile.id} value={profile.id}>
-                  {profile.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          
-          {activeProfileId && (
-            <div className="profile-actions">
-              <button
-                className="btn btn-secondary btn-sm"
-                onClick={() => {
-                  const profile = studyProfiles.find(p => p.id === activeProfileId);
-                  if (profile) {
-                    setEditingProfile(profile);
-                    setIsProfileModalOpen(true);
-                  }
-                }}
-              >
-                <Edit2 size={14} />
-                Editar
-              </button>
-              <button
-                className="btn btn-danger btn-sm"
-                onClick={() => {
-                  setConfirmationDialog({
-                    isOpen: true,
-                    title: 'Confirmar Exclusão',
-                    message: 'Tem certeza que deseja deletar este perfil? Todos os dados relacionados serão perdidos.',
-                    onConfirm: () => {
-                      handleDeleteProfile(activeProfileId);
-                      setConfirmationDialog({ isOpen: false, title: '', message: '', onConfirm: () => {} });
-                    }
-                  });
-                }}
-              >
-                <Trash2 size={14} />
-                Deletar
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
 
 export const AppHeader = ({
   setIsProgressReportModalOpen,
@@ -114,107 +19,134 @@ export const AppHeader = ({
   setActiveProfileId,
   onOpenProfileModal
 }) => {
+  const activeProfile = studyProfiles?.find(profile => profile.id === activeProfileId);
+  const examDate = activeProfile?.examDate;
+  const daysUntilExam = examDate
+    ? Math.ceil((new Date(examDate).setHours(0, 0, 0, 0) - new Date().setHours(0, 0, 0, 0)) / (1000 * 60 * 60 * 24))
+    : null;
+
   return (
-    <div className="app-header-unified">
-      <div className="header-main-section">
-        {/* Logo e Título */}
-        <div className="header-brand">
-          <div className="brand-icon">
-            <BookOpen size={24} color="white" />
+    <header className="card relative overflow-hidden p-6 sm:p-8">
+      <div className="pointer-events-none absolute -top-24 right-0 h-48 w-48 rounded-full bg-sky-500/25 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-24 left-24 h-48 w-48 rounded-full bg-indigo-500/15 blur-3xl" />
+
+      <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex max-w-2xl flex-col gap-6">
+          <div className="flex items-start gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-sky-500/20 text-sky-200">
+              <BookOpen size={28} />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.4em] text-sky-100/60">Organizador</p>
+              <h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">Painel de Estudos</h1>
+              <p className="mt-3 text-sm leading-relaxed text-slate-300">
+                {activeProfile
+                  ? `Foque no concurso ${activeProfile.name} e acompanhe o desempenho do seu ciclo de estudos em tempo real.`
+                  : 'Crie um concurso para começar a organizar objetivos, cronogramas e revisões personalizadas.'}
+              </p>
+            </div>
           </div>
-          <div className="brand-text">
-            <h1 className="brand-title">📚 Organizador de Estudos</h1>
-            <p className="brand-subtitle">Seu painel para conquistar os concursos!</p>
+
+          <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-slate-300">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-sky-100">
+              <Sparkles size={14} />
+              {activeProfile?.institution || 'Personalize seu estudo'}
+            </span>
+            {examDate && (
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                <CalendarDays size={14} />
+                {daysUntilExam > 0
+                  ? `${daysUntilExam} ${daysUntilExam === 1 ? 'dia' : 'dias'} para a prova`
+                  : 'Prova em andamento'}
+              </span>
+            )}
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+              <Users size={14} />
+              {studyProfiles.length} {studyProfiles.length === 1 ? 'perfil' : 'perfis'}
+            </span>
           </div>
         </div>
 
-        {/* Controles de Ação */}
-        <div className="header-actions">
+        <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
           <button
+            type="button"
             onClick={() => setIsProgressReportModalOpen(true)}
-            className="action-btn primary"
+            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-sky-400/60 hover:bg-white/20"
             title="Relatório (Ctrl+R)"
           >
             <BarChart3 size={16} />
-            <span>Relatório</span>
+            Relatório
           </button>
 
           <button
+            type="button"
             onClick={handleExportData}
-            className="action-btn secondary"
-            title="Exportar (Ctrl+E)"
+            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-emerald-400/60 hover:bg-emerald-500/20"
+            title="Exportar dados"
           >
             <Download size={16} />
-            <span>Exportar</span>
+            Exportar
           </button>
 
-          <label className="action-btn secondary" style={{ cursor: 'pointer' }} title="Importar dados">
+          <label
+            className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-sky-400/60 hover:bg-sky-500/20"
+            title="Importar dados"
+          >
             <Upload size={16} />
-            <span>Importar</span>
+            Importar
             <input
               type="file"
               accept=".json"
               onChange={(e) => {
-                const file = e.target.files[0];
+                const file = e.target.files?.[0];
                 if (file) {
                   handleImportData(file);
                 }
               }}
-              style={{ display: 'none' }}
+              className="hidden"
             />
           </label>
         </div>
       </div>
 
-      {/* Seção de Perfil */}
-      <div className="header-profile-section">
-        <div className="profile-controls">
-          <div className="profile-selector">
-            <Users size={16} className="profile-icon" />
-            <span className="profile-label">Concurso:</span>
-            {studyProfiles && studyProfiles.length > 0 ? (
-              <select
-                value={activeProfileId || ''}
-                onChange={(e) => setActiveProfileId(e.target.value)}
-                className="profile-select"
-              >
-                {studyProfiles.map(p => (
-                  <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-              </select>
-            ) : (
-              <span className="no-profile">Nenhum concurso criado</span>
-            )}
-          </div>
-
-          <div className="profile-actions">
-            <button
-              onClick={onOpenProfileModal}
-              className="profile-btn edit"
-              title="Gerenciar Concursos"
-            >
-              <Edit size={14} />
-              <span>Editar</span>
-            </button>
-
-            <button
-              onClick={onOpenProfileModal}
-              className="profile-btn create"
-              title="Novo Concurso (Ctrl+N)"
-            >
-              <Plus size={14} />
-              <span>Novo</span>
-            </button>
+      <div className="relative mt-8 grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-4 backdrop-blur">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/15 text-sky-200">
+              <Users size={18} />
+            </div>
+            <div className="flex-1">
+              <span className="text-xs font-medium uppercase tracking-wide text-slate-400">Concurso ativo</span>
+              {studyProfiles.length > 0 ? (
+                <select
+                  value={activeProfileId || ''}
+                  onChange={(e) => setActiveProfileId(e.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                >
+                  <option value="">Selecione um concurso</option>
+                  {studyProfiles.map(profile => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <p className="mt-2 text-sm text-slate-400">Nenhum concurso cadastrado ainda.</p>
+              )}
+            </div>
           </div>
         </div>
 
-        <div className="connection-status">
-          <div className="status-indicator">
-            <div className="status-dot"></div>
-            <span>Firebase Conectado</span>
-          </div>
-        </div>
+        <button
+          type="button"
+          onClick={onOpenProfileModal}
+          className="inline-flex items-center justify-center gap-2 rounded-2xl border border-sky-500/50 bg-sky-500/10 px-4 py-3 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+        >
+          <PlusCircle size={16} />
+          Gerenciar concursos
+        </button>
       </div>
-    </div>
+    </header>
   );
 };
+

--- a/src/components/dashboard/GlobalConcursosCard.jsx
+++ b/src/components/dashboard/GlobalConcursosCard.jsx
@@ -2,24 +2,67 @@ import React from 'react';
 
 export default function GlobalConcursosCard({ concursos, syllabusItems, onImport }) {
   if (!concursos || concursos.length === 0) return null;
+
   return (
-    <div className="card">
-      <h2>Concursos Globais</h2>
+    <div className="card space-y-4 p-6 sm:p-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <span className="text-xs uppercase tracking-wide text-slate-300">Biblioteca global</span>
+          <h2 className="mt-1 text-xl font-semibold text-white">Concursos sugeridos</h2>
+          <p className="mt-2 text-sm text-slate-400">
+            Importe rapidamente editais completos estruturados por especialistas.
+          </p>
+        </div>
+        <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-200">
+          {concursos.length} disponíveis
+        </span>
+      </div>
+
       <div className="space-y-3">
-        {concursos.map(c => {
-          const totalSubtopicos = (c.materias||[]).reduce((acc,m)=> acc + (m.submaterias||[]).reduce((a,s)=> a + (s.subtopicos||[]).length,0),0);
-          const importedCount = syllabusItems.filter(i=> i.concursoId===c.id).length;
-          const pct = totalSubtopicos>0? ((importedCount/totalSubtopicos)*100).toFixed(1):'0';
+        {concursos.map(concurso => {
+          const totalSubtopicos = (concurso.materias || []).reduce(
+            (acc, materia) =>
+              acc + (materia.submaterias || []).reduce(
+                (subAcc, submateria) => subAcc + (submateria.subtopicos || []).length,
+                0
+              ),
+            0
+          );
+          const importedCount = syllabusItems.filter(item => item.concursoId === concurso.id).length;
+          const progress = totalSubtopicos > 0 ? ((importedCount / totalSubtopicos) * 100).toFixed(1) : '0';
+
           return (
-            <div key={c.id} className="p-3 border rounded bg-white shadow-sm">
-              <div className="flex items-center justify-between mb-1">
-                <div className="font-semibold text-sm text-slate-800">{c.nome}</div>
-                <button className="btn btn-secondary !py-1 !px-2 text-xs" onClick={()=>onImport(c.id)}>Importar</button>
+            <div
+              key={concurso.id}
+              className="rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-sky-400/40"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-white">{concurso.nome}</p>
+                  {concurso.banca && <p className="text-xs text-slate-400">Banca: {concurso.banca}</p>}
+                  {concurso.orgao && <p className="text-xs text-slate-500">{concurso.orgao}</p>}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onImport(concurso.id)}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/10"
+                >
+                  Importar
+                </button>
               </div>
-              <div className="text-[11px] text-slate-500 mb-1">{importedCount}/{totalSubtopicos} subtópicos ({pct}%)</div>
-              <div className="w-full h-2 bg-slate-200 rounded">
-                <div className="h-2 bg-indigo-600 rounded" style={{width: pct+'%'}}></div>
+
+              <div className="mt-3 flex items-center gap-3 text-xs text-slate-300">
+                <div className="h-2 flex-1 rounded-full bg-slate-800">
+                  <div
+                    className="h-2 rounded-full bg-sky-500"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+                <span className="font-semibold text-slate-200">{progress}%</span>
               </div>
+              <p className="mt-2 text-[11px] text-slate-400">
+                {importedCount}/{totalSubtopicos} subtópicos importados
+              </p>
             </div>
           );
         })}

--- a/src/index.css
+++ b/src/index.css
@@ -69,6 +69,92 @@
 
 /* Component styles */
 @layer components {
+  .app-shell {
+    position: relative;
+    min-height: 100vh;
+    background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 55%), #020617;
+    color: #e2e8f0;
+    overflow-x: hidden;
+  }
+
+  .app-shell__gradient,
+  .app-shell__grid,
+  .app-shell__blur {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .app-shell__gradient {
+    background: radial-gradient(circle at top, rgba(37, 99, 235, 0.18), transparent 60%),
+      radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.08), transparent 60%);
+    opacity: 0.95;
+  }
+
+  .app-shell__grid {
+    background-image:
+      linear-gradient(0deg, rgba(148, 163, 184, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(148, 163, 184, 0.04) 1px, transparent 1px);
+    background-size: 40px 40px;
+    mix-blend-mode: lighten;
+    opacity: 0.45;
+  }
+
+  .app-shell__blur {
+    border-radius: 9999px;
+    filter: blur(120px);
+    opacity: 0.7;
+  }
+
+  .app-shell__blur--1 {
+    top: -160px;
+    left: -120px;
+    width: 380px;
+    height: 380px;
+    background: rgba(91, 33, 182, 0.32);
+  }
+
+  .app-shell__blur--2 {
+    bottom: -140px;
+    right: -100px;
+    width: 320px;
+    height: 320px;
+    background: rgba(56, 189, 248, 0.28);
+  }
+
+  .app-shell__content {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 6rem;
+  }
+
+  .loading-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .loading-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .loading-message {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #f1f5f9;
+  }
+
+  .loading-subtext {
+    font-size: 0.85rem;
+    color: rgba(148, 163, 184, 0.85);
+  }
+
   /* Button base styles - Modern Design */
   .btn {
     display: inline-flex;
@@ -140,28 +226,22 @@
   
   /* Card styles - Modern Design */
   .card {
-    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 41, 59, 0.95) 100%);
-    border-radius: 16px;
-    box-shadow:
-      0 20px 25px -5px rgba(0, 0, 0, 0.3),
-      0 10px 10px -5px rgba(0, 0, 0, 0.1),
-      inset 0 1px 0 rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(20px);
-    padding: 16px;
-    margin-bottom: 16px;
     position: relative;
+    background: linear-gradient(155deg, rgba(15, 23, 42, 0.86) 0%, rgba(2, 6, 23, 0.92) 100%);
+    border-radius: 22px;
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    box-shadow: 0 32px 55px -35px rgba(15, 23, 42, 0.85);
+    backdrop-filter: blur(18px);
+    padding: 24px;
     overflow: hidden;
   }
 
   .card::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.05) 0%, transparent 100%);
+    inset: 0;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), transparent 65%);
+    opacity: 0.6;
     pointer-events: none;
   }
   
@@ -281,24 +361,55 @@
 }
 
 .stat-card {
-  background: rgba(30, 41, 59, 0.9);
-  border-radius: 6px;
-  padding: 12px;
-  border: 1px solid rgba(71, 85, 105, 0.3);
-  text-align: center;
-  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.1), rgba(15, 23, 42, 0.35));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: 18px;
+  text-align: left;
+  backdrop-filter: blur(16px);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.35);
+  box-shadow: 0 26px 45px -30px rgba(56, 189, 248, 0.55);
+}
+
+.modern-stat {
+  min-height: 150px;
 }
 
 .stat-value {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #3b82f6;
-  margin-bottom: 4px;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #f8fafc;
 }
 
 .stat-label {
-  color: #94a3b8;
-  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.subject-card {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 28px 50px -35px rgba(15, 23, 42, 0.7);
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.subject-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.4);
+  box-shadow: 0 30px 55px -32px rgba(59, 130, 246, 0.45);
 }
 
 /* Subjects overview */
@@ -654,12 +765,6 @@
   border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
-.card {
-  background: rgba(15, 23, 42, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
-}
-
 .subject-overview-header {
   margin-bottom: 24px;
 }
@@ -845,6 +950,7 @@
   background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #334155 100%);
 }
 
+
 .loading-container {
   display: flex;
   justify-content: center;
@@ -855,12 +961,13 @@
 }
 
 .loading-spinner {
-  width: 50px;
-  height: 50px;
-  border: 3px solid rgba(255, 255, 255, 0.3);
-  border-top: 3px solid #3b82f6;
+  width: 56px;
+  height: 56px;
+  border: 4px solid rgba(148, 163, 184, 0.25);
+  border-top-color: rgba(56, 189, 248, 0.85);
   border-radius: 50%;
-  animation: spin 1s linear infinite;
+  animation: spin 0.9s linear infinite;
+  box-shadow: 0 0 25px rgba(56, 189, 248, 0.25);
 }
 
 @keyframes spin {
@@ -1938,53 +2045,63 @@
 
 /* Ciclo de Estudos Visual */
 .study-cycle-indicator {
-  margin-top: 20px;
-  padding: 15px;
-  background: rgba(59, 130, 246, 0.1);
-  border-radius: 8px;
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  margin-top: 16px;
+  padding: 18px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(139, 92, 246, 0.06));
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(12px);
 }
 
 .study-cycle-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: 10px;
+  margin-bottom: 16px;
   font-weight: 600;
-  color: #3B82F6;
+  color: #e2e8f0;
 }
 
 .study-cycle-icon {
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .study-cycle-title {
-  font-size: 14px;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .study-cycle-subjects {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
 }
 
 .study-cycle-item {
   display: flex;
   flex-direction: column;
-  padding: 8px 12px;
-  border-radius: 6px;
-  min-width: 120px;
-  font-size: 12px;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+  min-height: 72px;
 }
 
 .cycle-subject-name {
   font-weight: 600;
-  margin-bottom: 2px;
+  font-size: 0.9rem;
+  color: #f8fafc;
 }
 
 .cycle-subject-weight {
-  color: #6B7280;
-  font-size: 11px;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 /* Modal de Sessão - Correção de scroll */


### PR DESCRIPTION
## Summary
- redesign the main dashboard with a glassmorphism shell, refreshed quick stats, and new sidebar panels for revisões, próximas sessões e simulados
- modernize the application header with a hero-style welcome, action buttons, and an inline profile selector
- refresh the concursos globais card and shared CSS tokens for cards, stats, and study-cycle visuals to match the new UI

## Testing
- npm run lint *(fails: ESLint configuration not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d56875caec832db51b6d3049ea03d3