### PR TITLE
Add Estudei experience navigator hub

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,29 @@
 import React, { useState, useEffect } from 'react';
-import { PlusCircle, BarChart3, Eye } from 'lucide-react';
+import {
+  PlusCircle,
+  Eye,
+  Clock,
+  Activity,
+  Target,
+  Percent,
+  Upload,
+  CalendarClock,
+  AlertTriangle,
+  CalendarDays,
+  ChevronRight
+} from 'lucide-react';
 
 // Importar componentes
 import { ProfileModal, SubjectModal, ItemDetailsModal, SyllabusModal, ProgressReportModal, SessionHistoryModal } from './components/Modals';
 import { SessionModal } from './components/SessionModal';
 import { SubjectsOverview } from './components/SubjectsOverview';
 import { SubjectsManagement } from './components/SubjectsManagement';
-import { AppHeader, ProfileSection } from './components/Header';
+import { AppHeader } from './components/Header';
 import { Calendar } from './components/Calendar';
 import ContestComparison from './components/ContestComparison';
 import { fetchGlobalEditais } from './services/globalEditaisService';
 import GlobalConcursosCard from './components/dashboard/GlobalConcursosCard';
+import { ExperienceNavigator } from './components/dashboard/ExperienceNavigator';
 import ImportConcursoModal from './components/import/ImportConcursoModal';
 
 // Importar serviços
@@ -30,7 +43,6 @@ function App() {
   const [selectedSyllabusItem, setSelectedSyllabusItem] = useState(null);
   const [isItemDetailsModalOpen, setIsItemDetailsModalOpen] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('Carregando dados...');
-  const [currentView, setCurrentView] = useState('overview'); // 'overview', 'subjects', 'calendar', 'reports'
 
   const [studyProfiles, setStudyProfiles] = useState([]);
   const [activeProfileId, setActiveProfileId] = useState(null);
@@ -377,68 +389,16 @@ function App() {
 
   // Componente de Loading
   const LoadingSpinner = () => (
-    <div className="loading-container">
+    <div className="loading-state">
       <div className="loading-spinner" />
-      <p className="loading-message">{loadingMessage}</p>
-      <div className="loading-progress">
-        <div className="loading-bar"></div>
+      <div className="loading-copy">
+        <p className="loading-message">{loadingMessage}</p>
+        <p className="loading-subtext">Preparando seu ambiente de estudos personalizado...</p>
       </div>
     </div>
   );
 
   // Componente de Breadcrumb
-  const Breadcrumb = () => {
-    const activeProfile = studyProfiles.find(p => p.id === activeProfileId);
-    const viewNames = {
-      overview: 'Visão Geral',
-      subjects: 'Matérias',
-      calendar: 'Calendário',
-      reports: 'Relatórios'
-    };
-
-    return (
-      <div className="breadcrumb">
-        <span className="breadcrumb-item">
-          📚 {activeProfile?.name || 'Nenhum Concurso'}
-        </span>
-        <span className="breadcrumb-separator">›</span>
-        <span className="breadcrumb-item active">
-          {viewNames[currentView]}
-        </span>
-      </div>
-    );
-  };
-
-  // Componente de Estatísticas Rápidas
-  const QuickStats = () => {
-    const totalSubjects = activeSubjects.length;
-    const totalItems = activeSyllabusItems.length;
-    const studiedItems = activeSyllabusItems.filter(item => item.isStudied).length;
-    const studiedPercentage = totalItems > 0 ? ((studiedItems / totalItems) * 100).toFixed(0) : 0;
-    const totalHours = activeSessions.reduce((sum, session) => sum + session.duration, 0);
-
-    return (
-      <div className="quick-stats">
-        <div className="stat-item">
-          <span className="stat-value">{totalSubjects}</span>
-          <span className="stat-label">Matérias</span>
-        </div>
-        <div className="stat-item">
-          <span className="stat-value">{studiedPercentage}%</span>
-          <span className="stat-label">Progresso</span>
-        </div>
-        <div className="stat-item">
-          <span className="stat-value">{totalHours.toFixed(1)}h</span>
-          <span className="stat-label">Estudadas</span>
-        </div>
-        <div className="stat-item">
-          <span className="stat-value">{studiedItems}/{totalItems}</span>
-          <span className="stat-label">Itens</span>
-        </div>
-      </div>
-    );
-  };
-
   // Componente de Toast Melhorado
   const Toast = ({ message, type, isVisible }) => {
     if (!isVisible) return null;
@@ -622,203 +582,467 @@ function App() {
   const activeSubjects = subjects.filter(subject => subject.profileId === activeProfileId);
   const activeSessions = studySessions.filter(session => session.profileId === activeProfileId);
   const activeSimulados = simulados.filter(s => s.profileId === activeProfileId);
-  const activeSyllabusItems = syllabusItems.filter(item => 
+  const activeSyllabusItems = syllabusItems.filter(item =>
     activeSubjects.some(subject => subject.id === item.subjectId)
   );
+
+  const activeProfile = studyProfiles.find(profile => profile.id === activeProfileId);
+  const subjectLookup = new Map(activeSubjects.map(subject => [subject.id, subject]));
+  const todayISO = new Date().toISOString().split('T')[0];
+
+  const formatDateLabel = (dateString) => {
+    if (!dateString) return '-';
+    const parsed = new Date(dateString);
+    if (Number.isNaN(parsed.getTime())) return '-';
+    return parsed.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+  };
+
+  const formatDuration = (minutes) => {
+    if (!minutes) return '0h';
+    const hours = minutes / 60;
+    if (hours >= 1) {
+      return `${hours.toFixed(1)}h`;
+    }
+    return `${Math.round(minutes)}min`;
+  };
+
+  const getSubjectLabel = (subjectId) => subjectLookup.get(subjectId)?.name || 'Sem matéria';
+
+  const totalHoursStudied = activeSessions.reduce((sum, session) => sum + (session.duration || 0), 0) / 60;
+  const totalItems = activeSyllabusItems.length;
+  const studiedItems = activeSyllabusItems.filter(item => item.isStudied).length;
+  const studiedPercentage = totalItems > 0 ? (studiedItems / totalItems) * 100 : 0;
+  const nextReviewLabel = getNextReviewDate();
+
+  const overviewStats = [
+    {
+      label: 'Horas estudadas',
+      value: `${totalHoursStudied.toFixed(1)}h`,
+      description: 'Tempo total dedicado ao concurso atual.',
+      icon: Clock
+    },
+    {
+      label: 'Sessões registradas',
+      value: activeSessions.length,
+      description: 'Sprints de estudo concluídos.',
+      icon: Activity
+    },
+    {
+      label: 'Simulados feitos',
+      value: activeSimulados.length,
+      description: 'Simulados cadastrados para este concurso.',
+      icon: Target
+    },
+    {
+      label: 'Progresso do edital',
+      value: `${Math.round(studiedPercentage)}%`,
+      description: `${studiedItems}/${totalItems || 0} itens concluídos.`,
+      icon: Percent
+    },
+    {
+      label: 'Próxima revisão',
+      value: nextReviewLabel,
+      description: 'Data sugerida conforme seu ciclo de revisões.',
+      icon: CalendarClock
+    }
+  ];
+
+  const urgentReviewItems = getUrgentReviews().slice(0, 5);
+  const upcomingSessions = [...activeSessions]
+    .filter(session => session.date && session.date >= todayISO)
+    .sort((a, b) => new Date(a.date) - new Date(b.date))
+    .slice(0, 4);
+  const upcomingSimulados = [...activeSimulados]
+    .filter(simulado => simulado.data)
+    .sort((a, b) => new Date(a.data) - new Date(b.data))
+    .slice(0, 3);
 
   // Renderização condicional baseada no estado de carregamento
   if (isLoading) {
     return (
-      <div className="app-container">
-        <LoadingSpinner />
+      <div className="app-shell">
+        <div className="app-shell__gradient" />
+        <div className="app-shell__grid" />
+        <div className="app-shell__blur app-shell__blur--1" />
+        <div className="app-shell__blur app-shell__blur--2" />
+        <div className="app-shell__content flex items-center justify-center">
+          <div className="card w-full max-w-md p-10 text-center">
+            <LoadingSpinner />
+          </div>
+        </div>
       </div>
     );
   }
 
   // Interface principal
   return (
-    <div className="app-container mx-auto" style={{maxWidth:'1400px', padding:'0 1rem'}}>
-      {/* Header */}
-      <AppHeader
-        setIsProgressReportModalOpen={setIsProgressReportModalOpen}
-        handleExportData={handleExportData}
-        handleImportData={handleImportData}
-        studyProfiles={studyProfiles}
-        activeProfileId={activeProfileId}
-        setActiveProfileId={handleSetActiveProfile}
-        onOpenProfileModal={() => setIsProfileModalOpen(true)}
-      />
+    <>
+      <div className="app-shell">
+        <div className="app-shell__gradient" />
+        <div className="app-shell__grid" />
+        <div className="app-shell__blur app-shell__blur--1" />
+        <div className="app-shell__blur app-shell__blur--2" />
+        <div className="app-shell__content space-y-8">
+        <AppHeader
+          setIsProgressReportModalOpen={setIsProgressReportModalOpen}
+          handleExportData={handleExportData}
+          handleImportData={handleImportData}
+          studyProfiles={studyProfiles}
+          activeProfileId={activeProfileId}
+          setActiveProfileId={handleSetActiveProfile}
+          onOpenProfileModal={() => setIsProfileModalOpen(true)}
+        />
 
-      {/* Breadcrumb e Estatísticas */}
-      {activeProfileId && (
-        <div className="navigation-section">
-          <Breadcrumb />
-          <QuickStats />
-        </div>
-      )}
-
-      {/* Conteúdo Principal */}
-      {!activeProfileId ? (
-        <div className="card">
-          <div className="welcome-section">
-            <h2>Bem-vindo ao Organizador de Estudos!</h2>
-            <p>Crie ou selecione um perfil de concurso para começar a organizar seus estudos.</p>
-            <button
-              className="btn btn-primary"
-              onClick={() => setIsProfileModalOpen(true)}
-            >
-              <PlusCircle size={20} />
-              Criar Primeiro Perfil
-            </button>
+        {!activeProfileId ? (
+          <div className="card space-y-4 p-10 text-center">
+            <h2 className="text-2xl font-semibold text-white">Comece seu planejamento</h2>
+            <p className="text-sm text-slate-300">
+              Crie um concurso para visualizar estatísticas, metas e revisões em um único painel.
+            </p>
+            <div className="flex justify-center">
+              <button
+                className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-5 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                onClick={() => setIsProfileModalOpen(true)}
+              >
+                <PlusCircle size={18} />
+                Criar primeiro concurso
+              </button>
+            </div>
           </div>
-        </div>
-      ) : (
-        <div className="space-y-6" style={{ maxWidth: '1150px', margin: '0 auto' }}>
-          {/* Estatísticas Rápidas */}
-          <div className="card">
-            <h2>
-              <BarChart3 size={20} />
-              Estatísticas Rápidas
-            </h2>
-            <div className="stats-grid">
-              <div className="stat-card">
-                <div className="stat-value">{(activeSessions.reduce((total, session) => total + (session.duration || 0), 0) / 60).toFixed(1)}h</div>
-                <div className="stat-label">Total Estudado</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">{activeSessions.length}</div>
-                <div className="stat-label">Sessões</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">{activeSimulados.length}</div>
-                <div className="stat-label">Simulados</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">
-                  {activeSyllabusItems.length > 0
-                    ? (activeSyllabusItems.reduce((sum, item) => sum + (item.accuracy || 0), 0) / activeSyllabusItems.length).toFixed(0)
-                    : 0}%
+        ) : (
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+            <section className="space-y-6">
+              <div className="card space-y-6 p-6 sm:p-8">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <span className="text-xs uppercase tracking-[0.35em] text-sky-100/70">Visão geral</span>
+                    <h2 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">
+                      {activeProfile?.name || 'Seu concurso'}
+                    </h2>
+                    <p className="mt-3 text-sm text-slate-300">
+                      {activeProfile?.description
+                        ? activeProfile.description
+                        : 'Acompanhe horas estudadas, simulados e revisões em um único lugar.'}
+                    </p>
+                  </div>
+                  {activeProfile?.examDate && (
+                    <div className="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-right">
+                      <span className="text-xs uppercase tracking-wide text-slate-400">Data da prova</span>
+                      <p className="mt-2 text-lg font-semibold text-white">
+                        {new Date(activeProfile.examDate).toLocaleDateString('pt-BR')}
+                      </p>
+                    </div>
+                  )}
                 </div>
-                <div className="stat-label">Média de Acerto Geral</div>
-              </div>
-              <div className="stat-card">
-                <div className="stat-value">{getNextReviewDate()}</div>
-                <div className="stat-label">Próxima Revisão Urgente</div>
-              </div>
-            </div>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button className="btn btn-primary" onClick={() => { setIsSimuladoModalOpen(true); }}>Registrar Simulado</button>
-              {globalEditais.length > 0 && activeSubjects.length > 0 && (
-                <button className="btn btn-secondary" onClick={() => setIsImportEditalOpen(true)}>Importar Itens de Edital</button>
-              )}
-            </div>
 
-            {/* Ciclo de Estudos Visual */}
-            {activeSubjects.length > 0 && (
-              <div className="study-cycle-indicator">
-                <div className="study-cycle-header">
-                  <span className="study-cycle-icon">🔄</span>
-                  <span className="study-cycle-title">Ciclo de Estudos Visual</span>
-                </div>
-                <div className="study-cycle-subjects">
-                  {activeSubjects.map(subject => (
-                    <div
-                      key={subject.id}
-                      className="study-cycle-item"
-                      style={{
-                        backgroundColor: subject.color + '20',
-                        borderLeft: `3px solid ${subject.color}`
-                      }}
-                    >
-                      <span className="cycle-subject-name">{subject.name}</span>
-                      <span className="cycle-subject-weight">Peso: {subject.weight || 1}</span>
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+                  {overviewStats.map(({ label, value, description, icon: Icon }) => (
+                    <div key={label} className="stat-card modern-stat">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-slate-400">{label}</p>
+                          <p className="mt-2 text-xl font-semibold text-white">{value}</p>
+                        </div>
+                        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/5 text-sky-200">
+                          <Icon size={18} />
+                        </div>
+                      </div>
+                      <p className="mt-3 text-xs text-slate-400">{description}</p>
                     </div>
                   ))}
                 </div>
-              </div>
-            )}
-          </div>
 
-          {activeSubjects.length === 0 ? (
-            <div className="card">
-              <div className="welcome-section">
-                <h2>Nenhuma matéria cadastrada</h2>
-                <p>Adicione sua primeira matéria para começar a organizar seus estudos.</p>
-                <button
-                  className="btn btn-primary"
-                  onClick={() => setIsSubjectModalOpen(true)}
-                >
-                  <PlusCircle size={20} />
-                  Adicionar Primeira Matéria
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-6">
-              {/* Calendário de Estudos */}
-              <div className="card">
-                <Calendar
-                  studySessions={activeSessions}
-                  syllabusItems={activeSyllabusItems}
-                  onDateClick={(date) => {
-                    // Aqui pode abrir um modal com detalhes do dia
-                  }}
-                />
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                    onClick={() => {
+                      setEditingSession(null);
+                      setCurrentSubjectForSession(null);
+                      setInitialSessionData(null);
+                      setIsSessionModalOpen(true);
+                    }}
+                  >
+                    <CalendarDays size={16} />
+                    Registrar sessão
+                  </button>
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                    onClick={() => setIsSubjectModalOpen(true)}
+                  >
+                    <PlusCircle size={16} />
+                    Nova matéria
+                  </button>
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                    onClick={() => setIsSimuladoModalOpen(true)}
+                  >
+                    <Target size={16} />
+                    Registrar simulado
+                  </button>
+                  {globalEditais.length > 0 && activeSubjects.length > 0 && (
+                    <button
+                      className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                      onClick={() => setIsImportEditalOpen(true)}
+                    >
+                      <Upload size={16} />
+                      Importar edital
+                    </button>
+                  )}
+                </div>
+
+                {activeSubjects.length > 0 && (
+                  <div className="study-cycle-indicator">
+                    <div className="study-cycle-header">
+                      <span className="study-cycle-icon">🔄</span>
+                      <span className="study-cycle-title">Distribuição do ciclo de estudos</span>
+                    </div>
+                    <div className="study-cycle-subjects">
+                      {activeSubjects.map(subject => (
+                        <div
+                          key={subject.id}
+                          className="study-cycle-item"
+                          style={{
+                            backgroundColor: `${subject.color || '#38bdf8'}20`,
+                            borderLeft: `3px solid ${subject.color || '#38bdf8'}`
+                          }}
+                        >
+                          <span className="cycle-subject-name">{subject.name}</span>
+                          <span className="cycle-subject-weight">Peso: {subject.weight || 1}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
 
-              {/* Matérias (Gerenciamento) */}
-              <SubjectsManagement
+              <ExperienceNavigator
+                activeProfile={activeProfile}
                 subjects={activeSubjects}
-                studySessions={activeSessions}
-                setIsSubjectModalOpen={setIsSubjectModalOpen}
-                setCurrentSubjectForSession={setCurrentSubjectForSession}
-                setIsSessionModalOpen={setIsSessionModalOpen}
-                setCurrentSubjectForSyllabus={setCurrentSubjectForSyllabus}
-                setIsSyllabusModalOpen={setIsSyllabusModalOpen}
-                setEditingSubject={setEditingSubject}
-                setConfirmationDialog={setConfirmationDialog}
-                handleDeleteSubject={handleDeleteSubject}
-                getSubjectStudyTime={getSubjectStudyTime}
-                calculateSubjectProgress={calculateSubjectProgress}
-                setIsSessionHistoryModalOpen={setIsSessionHistoryModalOpen}
-                setSelectedSubjectForHistory={setSelectedSubjectForHistory}
+                sessions={activeSessions}
+                syllabusItems={activeSyllabusItems}
+                simulados={activeSimulados}
+                urgentReviewItems={urgentReviewItems}
+                upcomingSessions={upcomingSessions}
+                upcomingSimulados={upcomingSimulados}
+                nextReviewLabel={nextReviewLabel}
+                totalHoursStudied={totalHoursStudied}
+                studiedPercentage={studiedPercentage}
               />
 
-              {/* Visão Geral das Matérias e Edital */}
-              <div className="card">
-                <h2>
-                  <Eye size={20} />
-                  Visão Geral das Matérias e Edital
-                </h2>
-                <SubjectsOverview
-                  subjects={activeSubjects}
-                  syllabusItems={activeSyllabusItems}
-                  setSyllabusItems={setSyllabusItems}
-                  expandedSubjects={expandedSubjects}
-                  setExpandedSubjects={setExpandedSubjects}
-                  getSubjectStudyTime={getSubjectStudyTime}
-                  setSelectedSyllabusItem={setSelectedSyllabusItem}
-                  setIsItemDetailsModalOpen={setIsItemDetailsModalOpen}
-                  studySessions={activeSessions}
-                />
-              </div>
-              <GlobalConcursosCard concursos={concursosGlobais} syllabusItems={syllabusItems} onImport={(id) => { setIsImportConcursoOpen(true); setSelectedConcursoForImport(id); }} />
-              {concursosGlobais.length > 1 && (
-                <div className="card">
-                  <h2>
-                    <Eye size={20} />
-                    Comparação de Editais (Concursos Globais)
-                  </h2>
-                  <ContestComparison concursos={concursosGlobais} />
+              {activeSubjects.length === 0 ? (
+                <div className="card space-y-4 p-10 text-center">
+                  <h3 className="text-xl font-semibold text-white">Nenhuma matéria cadastrada</h3>
+                  <p className="text-sm text-slate-300">Adicione sua primeira matéria para liberar o ciclo de estudos.</p>
+                  <div className="flex justify-center">
+                    <button
+                      className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-5 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                      onClick={() => setIsSubjectModalOpen(true)}
+                    >
+                      <PlusCircle size={16} />
+                      Adicionar matéria
+                    </button>
+                  </div>
                 </div>
+              ) : (
+                <>
+                  <div className="card p-6 sm:p-8">
+                    <Calendar
+                      studySessions={activeSessions}
+                      syllabusItems={activeSyllabusItems}
+                      onDateClick={() => {}}
+                    />
+                  </div>
+
+                  <SubjectsManagement
+                    subjects={activeSubjects}
+                    studySessions={activeSessions}
+                    setIsSubjectModalOpen={setIsSubjectModalOpen}
+                    setCurrentSubjectForSession={setCurrentSubjectForSession}
+                    setIsSessionModalOpen={setIsSessionModalOpen}
+                    setCurrentSubjectForSyllabus={setCurrentSubjectForSyllabus}
+                    setIsSyllabusModalOpen={setIsSyllabusModalOpen}
+                    setEditingSubject={setEditingSubject}
+                    setConfirmationDialog={setConfirmationDialog}
+                    handleDeleteSubject={handleDeleteSubject}
+                    getSubjectStudyTime={getSubjectStudyTime}
+                    calculateSubjectProgress={calculateSubjectProgress}
+                    setIsSessionHistoryModalOpen={setIsSessionHistoryModalOpen}
+                    setSelectedSubjectForHistory={setSelectedSubjectForHistory}
+                  />
+
+                  <div className="card space-y-6 p-6 sm:p-8">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                      <div>
+                        <span className="text-xs uppercase tracking-[0.3em] text-slate-300">Edital</span>
+                        <h2 className="mt-1 text-xl font-semibold text-white">Visão geral das matérias</h2>
+                      </div>
+                      <span className="text-xs uppercase tracking-wide text-slate-400">
+                        {studiedItems}/{totalItems || 0} itens mapeados
+                      </span>
+                    </div>
+                    <SubjectsOverview
+                      subjects={activeSubjects}
+                      syllabusItems={activeSyllabusItems}
+                      setSyllabusItems={setSyllabusItems}
+                      expandedSubjects={expandedSubjects}
+                      setExpandedSubjects={setExpandedSubjects}
+                      getSubjectStudyTime={getSubjectStudyTime}
+                      setSelectedSyllabusItem={setSelectedSyllabusItem}
+                      setIsItemDetailsModalOpen={setIsItemDetailsModalOpen}
+                      studySessions={activeSessions}
+                    />
+                  </div>
+
+                  <GlobalConcursosCard
+                    concursos={concursosGlobais}
+                    syllabusItems={syllabusItems}
+                    onImport={(id) => {
+                      setIsImportConcursoOpen(true);
+                      setSelectedConcursoForImport(id);
+                    }}
+                  />
+
+                  {concursosGlobais.length > 1 && (
+                    <div className="card space-y-4 p-6 sm:p-8">
+                      <div className="flex items-center gap-2 text-slate-300">
+                        <Eye size={18} />
+                        <h3 className="text-lg font-semibold text-white">Comparação de editais</h3>
+                      </div>
+                      <ContestComparison concursos={concursosGlobais} />
+                    </div>
+                  )}
+                </>
               )}
-            </div>
-          )}
-        </div>
-      )}
+            </section>
+
+            <aside className="space-y-6">
+              <div className="card space-y-4 p-6">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-amber-200/80">Prioridades</span>
+                    <h3 className="mt-1 text-lg font-semibold text-white">Revisões urgentes</h3>
+                  </div>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/40 bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-200">
+                    <AlertTriangle size={14} />
+                    {urgentReviewItems.length}
+                  </span>
+                </div>
+                <div className="space-y-3">
+                  {urgentReviewItems.length > 0 ? (
+                    urgentReviewItems.map(item => (
+                      <div
+                        key={item.id}
+                        className="flex items-start justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-3 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-white">{item.name}</p>
+                          <p className="text-xs text-slate-400">{getSubjectLabel(item.subjectId)}</p>
+                        </div>
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-1 text-xs font-semibold text-amber-200">
+                          <CalendarClock size={12} />
+                          {formatDateLabel(item.nextReviewDate)}
+                        </span>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="rounded-xl border border-white/5 bg-white/5 px-3 py-4 text-sm text-slate-300">
+                      Nenhuma revisão urgente no momento. Continue avançando! ✨
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="card space-y-4 p-6">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-sky-200/80">Planejamento</span>
+                    <h3 className="mt-1 text-lg font-semibold text-white">Próximas sessões</h3>
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  {upcomingSessions.length > 0 ? (
+                    upcomingSessions.map(session => (
+                      <div
+                        key={session.id}
+                        className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 px-3 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-white">{getSubjectLabel(session.subjectId)}</p>
+                          <p className="text-xs text-slate-400">
+                            {formatDateLabel(session.date)} • {formatDuration(session.duration)}
+                          </p>
+                          {session.topics && (
+                            <p className="mt-1 text-xs text-slate-500">{session.topics}</p>
+                          )}
+                        </div>
+                        <ChevronRight size={16} className="text-slate-500" />
+                      </div>
+                    ))
+                  ) : (
+                    <div className="rounded-xl border border-white/5 bg-white/5 px-3 py-4 text-sm text-slate-300">
+                      Nenhuma sessão futura registrada.
+                      <button
+                        className="mt-3 inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                        onClick={() => {
+                          setEditingSession(null);
+                          setCurrentSubjectForSession(null);
+                          setInitialSessionData(null);
+                          setIsSessionModalOpen(true);
+                        }}
+                      >
+                        <CalendarDays size={14} />
+                        Planejar agora
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="card space-y-4 p-6">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-slate-300">Preparação</span>
+                    <h3 className="mt-1 text-lg font-semibold text-white">Próximos simulados</h3>
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  {upcomingSimulados.length > 0 ? (
+                    upcomingSimulados.map(simulado => (
+                      <div key={simulado.id} className="rounded-xl border border-white/10 bg-white/5 p-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-white">{formatDateLabel(simulado.data)}</p>
+                            <p className="text-xs text-slate-400 capitalize">{simulado.tipo || 'Simulado'}</p>
+                          </div>
+                          <Target size={18} className="text-sky-200" />
+                        </div>
+                        {simulado.notaFinal !== undefined && simulado.notaFinal !== null && (
+                          <p className="mt-2 text-xs text-slate-300">Nota final: {simulado.notaFinal}</p>
+                        )}
+                      </div>
+                    ))
+                  ) : (
+                    <div className="rounded-xl border border-white/5 bg-white/5 px-3 py-4 text-sm text-slate-300">
+                      Nenhum simulado agendado.
+                      <button
+                        className="mt-3 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/10"
+                        onClick={() => setIsSimuladoModalOpen(true)}
+                      >
+                        <Target size={14} />
+                        Criar simulado
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </aside>
+          </div>
+        )}
+      </div>
+      </div>
 
       {/* Modais */}
-      <ProfileModal 
+      <ProfileModal
         isOpen={isProfileModalOpen}
         onClose={() => {
           setIsProfileModalOpen(false);
@@ -966,7 +1190,7 @@ function App() {
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,108 +2,13 @@ import React from 'react';
 import {
   Users,
   PlusCircle,
-  Edit2,
-  Trash2,
   BarChart3,
   Download,
   Upload,
   BookOpen,
-  Edit,
-  Plus
+  Sparkles,
+  CalendarDays
 } from 'lucide-react';
-
-export const ProfileSection = ({ 
-  studyProfiles,
-  activeProfileId,
-  setActiveProfileId,
-  setIsProfileModalOpen,
-  setEditingProfile,
-  setConfirmationDialog,
-  handleDeleteProfile
-}) => {
-  return (
-    <div className="profile-section">
-      <div className="profile-header">
-        <div className="profile-title">
-          <Users size={20} />
-          <span>Perfis de Concurso</span>
-        </div>
-        <button
-          className="btn btn-primary btn-sm"
-          onClick={() => setIsProfileModalOpen(true)}
-        >
-          <PlusCircle size={14} />
-          Novo Perfil
-        </button>
-      </div>
-
-      {studyProfiles.length === 0 ? (
-        <div className="profile-empty">
-          <span>Nenhum perfil criado.</span>
-          <button
-            className="btn btn-primary btn-sm"
-            onClick={() => setIsProfileModalOpen(true)}
-          >
-            Criar Primeiro Perfil
-          </button>
-        </div>
-      ) : (
-        <div className="profile-content">
-          <div className="profile-selector">
-            <label>Concurso Ativo:</label>
-            <select
-              value={activeProfileId || ''}
-              onChange={(e) => setActiveProfileId(e.target.value)}
-              className="profile-dropdown"
-            >
-              <option value="">Selecione um perfil</option>
-              {studyProfiles.map(profile => (
-                <option key={profile.id} value={profile.id}>
-                  {profile.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          
-          {activeProfileId && (
-            <div className="profile-actions">
-              <button
-                className="btn btn-secondary btn-sm"
-                onClick={() => {
-                  const profile = studyProfiles.find(p => p.id === activeProfileId);
-                  if (profile) {
-                    setEditingProfile(profile);
-                    setIsProfileModalOpen(true);
-                  }
-                }}
-              >
-                <Edit2 size={14} />
-                Editar
-              </button>
-              <button
-                className="btn btn-danger btn-sm"
-                onClick={() => {
-                  setConfirmationDialog({
-                    isOpen: true,
-                    title: 'Confirmar Exclusão',
-                    message: 'Tem certeza que deseja deletar este perfil? Todos os dados relacionados serão perdidos.',
-                    onConfirm: () => {
-                      handleDeleteProfile(activeProfileId);
-                      setConfirmationDialog({ isOpen: false, title: '', message: '', onConfirm: () => {} });
-                    }
-                  });
-                }}
-              >
-                <Trash2 size={14} />
-                Deletar
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
 
 export const AppHeader = ({
   setIsProgressReportModalOpen,
@@ -114,107 +19,134 @@ export const AppHeader = ({
   setActiveProfileId,
   onOpenProfileModal
 }) => {
+  const activeProfile = studyProfiles?.find(profile => profile.id === activeProfileId);
+  const examDate = activeProfile?.examDate;
+  const daysUntilExam = examDate
+    ? Math.ceil((new Date(examDate).setHours(0, 0, 0, 0) - new Date().setHours(0, 0, 0, 0)) / (1000 * 60 * 60 * 24))
+    : null;
+
   return (
-    <div className="app-header-unified">
-      <div className="header-main-section">
-        {/* Logo e Título */}
-        <div className="header-brand">
-          <div className="brand-icon">
-            <BookOpen size={24} color="white" />
+    <header className="card relative overflow-hidden p-6 sm:p-8">
+      <div className="pointer-events-none absolute -top-24 right-0 h-48 w-48 rounded-full bg-sky-500/25 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-24 left-24 h-48 w-48 rounded-full bg-indigo-500/15 blur-3xl" />
+
+      <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex max-w-2xl flex-col gap-6">
+          <div className="flex items-start gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-sky-500/20 text-sky-200">
+              <BookOpen size={28} />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.4em] text-sky-100/60">Organizador</p>
+              <h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">Painel de Estudos</h1>
+              <p className="mt-3 text-sm leading-relaxed text-slate-300">
+                {activeProfile
+                  ? `Foque no concurso ${activeProfile.name} e acompanhe o desempenho do seu ciclo de estudos em tempo real.`
+                  : 'Crie um concurso para começar a organizar objetivos, cronogramas e revisões personalizadas.'}
+              </p>
+            </div>
           </div>
-          <div className="brand-text">
-            <h1 className="brand-title">📚 Organizador de Estudos</h1>
-            <p className="brand-subtitle">Seu painel para conquistar os concursos!</p>
+
+          <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-slate-300">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-sky-100">
+              <Sparkles size={14} />
+              {activeProfile?.institution || 'Personalize seu estudo'}
+            </span>
+            {examDate && (
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                <CalendarDays size={14} />
+                {daysUntilExam > 0
+                  ? `${daysUntilExam} ${daysUntilExam === 1 ? 'dia' : 'dias'} para a prova`
+                  : 'Prova em andamento'}
+              </span>
+            )}
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+              <Users size={14} />
+              {studyProfiles.length} {studyProfiles.length === 1 ? 'perfil' : 'perfis'}
+            </span>
           </div>
         </div>
 
-        {/* Controles de Ação */}
-        <div className="header-actions">
+        <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
           <button
+            type="button"
             onClick={() => setIsProgressReportModalOpen(true)}
-            className="action-btn primary"
+            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-sky-400/60 hover:bg-white/20"
             title="Relatório (Ctrl+R)"
           >
             <BarChart3 size={16} />
-            <span>Relatório</span>
+            Relatório
           </button>
 
           <button
+            type="button"
             onClick={handleExportData}
-            className="action-btn secondary"
-            title="Exportar (Ctrl+E)"
+            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-emerald-400/60 hover:bg-emerald-500/20"
+            title="Exportar dados"
           >
             <Download size={16} />
-            <span>Exportar</span>
+            Exportar
           </button>
 
-          <label className="action-btn secondary" style={{ cursor: 'pointer' }} title="Importar dados">
+          <label
+            className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-sky-400/60 hover:bg-sky-500/20"
+            title="Importar dados"
+          >
             <Upload size={16} />
-            <span>Importar</span>
+            Importar
             <input
               type="file"
               accept=".json"
               onChange={(e) => {
-                const file = e.target.files[0];
+                const file = e.target.files?.[0];
                 if (file) {
                   handleImportData(file);
                 }
               }}
-              style={{ display: 'none' }}
+              className="hidden"
             />
           </label>
         </div>
       </div>
 
-      {/* Seção de Perfil */}
-      <div className="header-profile-section">
-        <div className="profile-controls">
-          <div className="profile-selector">
-            <Users size={16} className="profile-icon" />
-            <span className="profile-label">Concurso:</span>
-            {studyProfiles && studyProfiles.length > 0 ? (
-              <select
-                value={activeProfileId || ''}
-                onChange={(e) => setActiveProfileId(e.target.value)}
-                className="profile-select"
-              >
-                {studyProfiles.map(p => (
-                  <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-              </select>
-            ) : (
-              <span className="no-profile">Nenhum concurso criado</span>
-            )}
-          </div>
-
-          <div className="profile-actions">
-            <button
-              onClick={onOpenProfileModal}
-              className="profile-btn edit"
-              title="Gerenciar Concursos"
-            >
-              <Edit size={14} />
-              <span>Editar</span>
-            </button>
-
-            <button
-              onClick={onOpenProfileModal}
-              className="profile-btn create"
-              title="Novo Concurso (Ctrl+N)"
-            >
-              <Plus size={14} />
-              <span>Novo</span>
-            </button>
+      <div className="relative mt-8 grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-4 backdrop-blur">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/15 text-sky-200">
+              <Users size={18} />
+            </div>
+            <div className="flex-1">
+              <span className="text-xs font-medium uppercase tracking-wide text-slate-400">Concurso ativo</span>
+              {studyProfiles.length > 0 ? (
+                <select
+                  value={activeProfileId || ''}
+                  onChange={(e) => setActiveProfileId(e.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                >
+                  <option value="">Selecione um concurso</option>
+                  {studyProfiles.map(profile => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <p className="mt-2 text-sm text-slate-400">Nenhum concurso cadastrado ainda.</p>
+              )}
+            </div>
           </div>
         </div>
 
-        <div className="connection-status">
-          <div className="status-indicator">
-            <div className="status-dot"></div>
-            <span>Firebase Conectado</span>
-          </div>
-        </div>
+        <button
+          type="button"
+          onClick={onOpenProfileModal}
+          className="inline-flex items-center justify-center gap-2 rounded-2xl border border-sky-500/50 bg-sky-500/10 px-4 py-3 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+        >
+          <PlusCircle size={16} />
+          Gerenciar concursos
+        </button>
       </div>
-    </div>
+    </header>
   );
 };
+

--- a/src/components/SubjectsOverview.jsx
+++ b/src/components/SubjectsOverview.jsx
@@ -1,5 +1,91 @@
 import React, { useState } from 'react';
-import { ChevronDown, ChevronUp, Eye, Edit2 } from 'lucide-react';
+import { CalendarClock, ChevronDown, ChevronUp, Eye, Edit2 } from 'lucide-react';
+
+const FILTER_OPTIONS = [
+  { id: 'todos', label: 'Todos os itens' },
+  { id: 'nao-estudados', label: 'Não estudados' },
+  { id: 'com-revisao', label: 'Com revisão' },
+  { id: 'estudados-sem-revisao', label: 'Revisão pendente' }
+];
+
+const getDaysDifferenceFromToday = (dateString) => {
+  if (!dateString) return null;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const target = new Date(dateString);
+  if (Number.isNaN(target.getTime())) return null;
+  target.setHours(0, 0, 0, 0);
+
+  const diffMs = target.getTime() - today.getTime();
+  return Math.round(diffMs / (1000 * 60 * 60 * 24));
+};
+
+const formatReviewDateLabel = (dateString) => {
+  if (!dateString) return '';
+
+  return new Date(dateString).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'short'
+  });
+};
+
+const describeReviewStatus = (dateString) => {
+  const diff = getDaysDifferenceFromToday(dateString);
+  if (diff === null) return null;
+
+  if (diff < 0) {
+    return {
+      variant: 'overdue',
+      label: `Atrasada há ${Math.abs(diff)}d (${formatReviewDateLabel(dateString)})`
+    };
+  }
+
+  if (diff === 0) {
+    return {
+      variant: 'today',
+      label: 'Hoje'
+    };
+  }
+
+  if (diff === 1) {
+    return {
+      variant: 'soon',
+      label: 'Amanhã'
+    };
+  }
+
+  return {
+    variant: 'upcoming',
+    label: `Em ${diff} dias (${formatReviewDateLabel(dateString)})`
+  };
+};
+
+const getAccuracyVariant = (accuracy) => {
+  if (accuracy >= 85) return 'high';
+  if (accuracy >= 70) return 'medium';
+  if (accuracy >= 50) return 'low';
+  return 'critical';
+};
+
+const getWeightColor = (weight) => {
+  const intensity = Math.min(weight / 100, 1);
+  return `rgba(248, 113, 113, ${0.25 + intensity * 0.35})`;
+};
+
+const truncate = (value = '', max = 40) => {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}…`;
+};
+
+const getSubjectUpcomingReview = (items) => {
+  const scheduled = items
+    .filter((item) => item.nextReviewDate)
+    .sort((a, b) => new Date(a.nextReviewDate) - new Date(b.nextReviewDate));
+
+  return scheduled[0];
+};
 
 export const SubjectsOverview = ({
   subjects,
@@ -16,18 +102,6 @@ export const SubjectsOverview = ({
   const [editingItem, setEditingItem] = useState(null);
   const [tempAccuracy, setTempAccuracy] = useState('');
   const [tempWeight, setTempWeight] = useState('');
-
-  const getAccuracyColor = (accuracy) => {
-    if (accuracy >= 80) return '#10b981'; // Verde
-    if (accuracy >= 60) return '#f59e0b'; // Amarelo
-    if (accuracy >= 40) return '#f97316'; // Laranja
-    return '#ef4444'; // Vermelho
-  };
-
-  const getWeightColor = (weight) => {
-    const intensity = Math.min(weight / 100, 1);
-    return `rgba(239, 68, 68, ${0.2 + intensity * 0.6})`; // Vermelho com intensidade baseada no peso
-  };
 
   const calculateNextReviewDate = (accuracy) => {
     const today = new Date();
@@ -161,7 +235,7 @@ export const SubjectsOverview = ({
   };
 
   return (
-    <div className="subjects-overview-new">
+    <div className="subjects-overview">
       {subjects.map(subject => {
         const subjectSyllabusItems = syllabusItems.filter(item => item.subjectId === subject.id);
         const filteredItems = filterItems(subjectSyllabusItems, subject.id);
@@ -174,325 +248,258 @@ export const SubjectsOverview = ({
           ? studiedItems.reduce((sum, item) => sum + (item.accuracy || 0), 0) / studiedItems.length
           : 0;
         const isExpanded = expandedSubjects[subject.id];
+        const upcomingReview = getSubjectUpcomingReview(subjectSyllabusItems);
+        const upcomingReviewStatus = upcomingReview ? describeReviewStatus(upcomingReview.nextReviewDate) : null;
+
+        const filterCounts = {
+          todos: subjectSyllabusItems.length,
+          'nao-estudados': subjectSyllabusItems.filter(item => !item.isStudied).length,
+          'com-revisao': subjectSyllabusItems.filter(item => item.isStudied && item.accuracy >= 0).length,
+          'estudados-sem-revisao': subjectSyllabusItems.filter(item => item.isStudied && (item.accuracy === undefined || item.accuracy < 0)).length
+        };
 
         return (
-          <div key={subject.id} className="subject-overview-new">
-            <div className="subject-header-new">
-              <div className="subject-info">
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
-                  <h3 className="subject-name" style={{ margin: 0 }}>{subject.name}</h3>
-                  <button
-                    className="expand-btn"
-                    onClick={() => {
-                      const newExpanded = { ...expandedSubjects };
-                      newExpanded[subject.id] = !newExpanded[subject.id];
-                      setExpandedSubjects(newExpanded);
-                    }}
-                  >
-                    {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-                  </button>
+          <article
+            key={subject.id}
+            className={`subject-card ${isExpanded ? 'subject-card--expanded' : ''}`}
+          >
+            <header className="subject-card__header">
+              <div className="subject-card__title-row">
+                <div>
+                  <h3 className="subject-card__title">{subject.name}</h3>
+                  <div className="subject-card__meta">
+                    <span className="subject-card__meta-pill">{subjectSyllabusItems.length} itens</span>
+                    <span className="subject-card__meta-pill">{studiedItems.length} estudados</span>
+                    <span className="subject-card__meta-pill">{totalStudyTime.toFixed(1)}h investidas</span>
+                  </div>
+                </div>
+                <button
+                  className="subject-card__toggle"
+                  onClick={() => {
+                    const newExpanded = { ...expandedSubjects };
+                    newExpanded[subject.id] = !newExpanded[subject.id];
+                    setExpandedSubjects(newExpanded);
+                  }}
+                  aria-label={isExpanded ? 'Recolher matéria' : 'Expandir matéria'}
+                  type="button"
+                >
+                  {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                </button>
+              </div>
+
+              <div className="subject-card__insights">
+                <div className="subject-card__progress">
+                  <div className="subject-card__progress-track">
+                    <div
+                      className="subject-card__progress-fill"
+                      style={{ width: `${studiedPercentage}%` }}
+                      aria-hidden
+                    />
+                  </div>
+                  <div className="subject-card__progress-meta">
+                    <span>{studiedPercentage.toFixed(0)}% do edital mapeado</span>
+                    <span>Média de acertos {averageAccuracy.toFixed(0)}%</span>
+                  </div>
                 </div>
 
-                {isExpanded && (
-                  <>
-                    <div className="subject-stats-compact" style={{
-                      marginBottom: '6px',
-                      fontSize: '0.7rem',
-                      color: '#64748b',
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      gap: '6px',
-                      alignItems: 'center'
-                    }}>
-                      <span style={{
-                        background: '#f1f5f9',
-                        padding: '2px 6px',
-                        borderRadius: '3px',
-                        fontWeight: '500',
-                        fontSize: '0.65rem'
-                      }}>
-                        {studiedItems.length} de {subjectSyllabusItems.length} itens ({studiedPercentage.toFixed(0)}%)
-                      </span>
-                      <span style={{
-                        background: '#f1f5f9',
-                        padding: '2px 6px',
-                        borderRadius: '3px',
-                        fontWeight: '500',
-                        fontSize: '0.65rem'
-                      }}>
-                        Média: {averageAccuracy.toFixed(0)}%
-                      </span>
-                      <span style={{
-                        background: '#f1f5f9',
-                        padding: '2px 6px',
-                        borderRadius: '3px',
-                        fontWeight: '500',
-                        fontSize: '0.65rem'
-                      }}>
-                        {totalStudyTime.toFixed(1)}h estudadas
-                      </span>
+                {upcomingReviewStatus ? (
+                  <div className={`subject-card__next-review subject-card__next-review--${upcomingReviewStatus.variant}`}>
+                    <CalendarClock size={16} />
+                    <div className="subject-card__next-review-text">
+                      <span className="value">{upcomingReviewStatus.label}</span>
+                      <span className="hint">{truncate(upcomingReview?.name || '')}</span>
                     </div>
-
-                    <div className="subject-controls" style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      marginBottom: '6px'
-                    }}>
-                      <div className="filter-tabs" style={{ display: 'flex', gap: '3px' }}>
-                        <button
-                          className={`filter-tab ${(!activeFilters[subject.id] || activeFilters[subject.id] === 'todos') ? 'active' : ''}`}
-                          onClick={() => setActiveFilters(prev => ({ ...prev, [subject.id]: 'todos' }))}
-                          style={{
-                            fontSize: '0.65rem',
-                            padding: '2px 6px',
-                            borderRadius: '3px',
-                            border: 'none',
-                            background: (!activeFilters[subject.id] || activeFilters[subject.id] === 'todos') ? '#3b82f6' : '#e2e8f0',
-                            color: (!activeFilters[subject.id] || activeFilters[subject.id] === 'todos') ? 'white' : '#64748b',
-                            cursor: 'pointer',
-                            fontWeight: '500'
-                          }}
-                        >
-                          Todos
-                        </button>
-                        <button
-                          className={`filter-tab ${activeFilters[subject.id] === 'nao-estudados' ? 'active' : ''}`}
-                          onClick={() => setActiveFilters(prev => ({ ...prev, [subject.id]: 'nao-estudados' }))}
-                          style={{
-                            fontSize: '0.65rem',
-                            padding: '2px 6px',
-                            borderRadius: '3px',
-                            border: 'none',
-                            background: activeFilters[subject.id] === 'nao-estudados' ? '#3b82f6' : '#e2e8f0',
-                            color: activeFilters[subject.id] === 'nao-estudados' ? 'white' : '#64748b',
-                            cursor: 'pointer',
-                            fontWeight: '500'
-                          }}
-                        >
-                          Não Estudados
-                        </button>
-                        <button
-                          className={`filter-tab ${activeFilters[subject.id] === 'com-revisao' ? 'active' : ''}`}
-                          onClick={() => setActiveFilters(prev => ({ ...prev, [subject.id]: 'com-revisao' }))}
-                          style={{
-                            fontSize: '0.65rem',
-                            padding: '2px 6px',
-                            borderRadius: '3px',
-                            border: 'none',
-                            background: activeFilters[subject.id] === 'com-revisao' ? '#3b82f6' : '#e2e8f0',
-                            color: activeFilters[subject.id] === 'com-revisao' ? 'white' : '#64748b',
-                            cursor: 'pointer',
-                            fontWeight: '500'
-                          }}
-                        >
-                          Com Revisão
-                        </button>
-                        <button
-                          className={`filter-tab ${activeFilters[subject.id] === 'estudados-sem-revisao' ? 'active' : ''}`}
-                          onClick={() => setActiveFilters(prev => ({ ...prev, [subject.id]: 'estudados-sem-revisao' }))}
-                          style={{
-                            fontSize: '0.65rem',
-                            padding: '2px 6px',
-                            borderRadius: '3px',
-                            border: 'none',
-                            background: activeFilters[subject.id] === 'estudados-sem-revisao' ? '#3b82f6' : '#e2e8f0',
-                            color: activeFilters[subject.id] === 'estudados-sem-revisao' ? 'white' : '#64748b',
-                            cursor: 'pointer',
-                            fontWeight: '500'
-                          }}
-                        >
-                          Estudados ({studiedPercentage.toFixed(0)}% Rev.)
-                        </button>
-                      </div>
-                    </div>
-                  </>
-                )}
-              </div>
-            </div>
-
-            {isExpanded && (
-              <div className="subject-content-new">
-                {filteredItems.length === 0 ? (
-                  <div className="no-items">
-                    Nenhum item corresponde ao filtro selecionado.
                   </div>
                 ) : (
-                  <div className="syllabus-items-list">
-                    {filteredItems.map(item => {
+                  studiedItems.length > 0 && (
+                    <div className="subject-card__next-review subject-card__next-review--empty">
+                      <CalendarClock size={16} />
+                      <div className="subject-card__next-review-text">
+                        <span className="value">Sem revisão agendada</span>
+                        <span className="hint">Defina a próxima revisão para manter o ritmo</span>
+                      </div>
+                    </div>
+                  )
+                )}
+              </div>
+            </header>
+
+            {isExpanded && (
+              <div className="subject-card__body">
+                <div className="subject-card__filters">
+                  {FILTER_OPTIONS.map(option => {
+                    const isActive = (activeFilters[subject.id] || 'todos') === option.id;
+
+                    return (
+                      <button
+                        key={option.id}
+                        className={`filter-pill ${isActive ? 'filter-pill--active' : ''}`}
+                        onClick={() => setActiveFilters(prev => ({ ...prev, [subject.id]: option.id }))}
+                        type="button"
+                      >
+                        <span>{option.label}</span>
+                        <span className="filter-pill__counter">{filterCounts[option.id]}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="subject-card__content">
+                  {filteredItems.length === 0 ? (
+                    <div className="subject-card__empty">Nenhum item corresponde ao filtro selecionado.</div>
+                  ) : (
+                    filteredItems.map(item => {
                       const hierarchyLevel = getHierarchyLevel(item.name);
                       const isSubItemFlag = isSubItem(item.name);
+                      const sessionAccuracy = getItemAccuracyFromSessions(item.id);
+                      const displayAccuracy = sessionAccuracy !== null && sessionAccuracy !== undefined
+                        ? sessionAccuracy
+                        : item.accuracy;
+                      const accuracyVariant = displayAccuracy !== undefined ? getAccuracyVariant(displayAccuracy) : null;
+                      const reviewStatus = item.nextReviewDate ? describeReviewStatus(item.nextReviewDate) : null;
 
                       return (
                         <div
                           key={item.id}
-                          className="syllabus-item-row"
+                          className={`syllabus-item-card ${isSubItemFlag ? 'syllabus-item-card--nested' : ''}`}
                           style={{
-                            backgroundColor: item.weight ? getWeightColor(item.weight) : undefined,
-                            marginLeft: `${hierarchyLevel * 20}px`, // Recuo de 20px por nível
-                            borderLeft: isSubItemFlag ? '3px solid rgba(59, 130, 246, 0.3)' : 'none',
-                            paddingLeft: isSubItemFlag ? '12px' : '8px'
+                            marginLeft: `${hierarchyLevel * 20}px`
                           }}
                         >
-                          <div className="item-content" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                          <div className="syllabus-item-card__header">
+                            <div className="syllabus-item-card__title-group">
                               <span
-                                className="item-name"
-                                style={{
-                                  fontSize: isSubItemFlag ? '0.85rem' : '0.9rem',
-                                  fontWeight: isSubItemFlag ? '400' : '500',
-                                  color: isSubItemFlag ? '#94a3b8' : '#e2e8f0'
+                                className="syllabus-item-card__marker"
+                                style={{ backgroundColor: item.weight !== undefined ? getWeightColor(item.weight) : undefined }}
+                                aria-hidden
+                              />
+                              <span className="syllabus-item-card__title">{item.name}</span>
+                            </div>
+                            <div className="syllabus-item-card__action-group">
+                              <button
+                                className="subject-card__icon-btn"
+                                onClick={() => {
+                                  setSelectedSyllabusItem(item);
+                                  setIsItemDetailsModalOpen(true);
                                 }}
+                                title="Histórico do item"
+                                type="button"
                               >
-                                {item.name}
+                                <Eye size={14} />
+                              </button>
+
+                              <button
+                                className="subject-card__icon-btn"
+                                onClick={() => {
+                                  setEditingItem(item.id);
+                                  setTempAccuracy(item.accuracy?.toString() || '');
+                                  setTempWeight(item.weight?.toString() || '');
+                                }}
+                                title="Editar percentuais"
+                                type="button"
+                              >
+                                <Edit2 size={14} />
+                              </button>
+                            </div>
+                          </div>
+
+                          <div className="syllabus-item-card__meta">
+                            {displayAccuracy !== undefined && (
+                              <span
+                                className={`item-chip item-chip--accuracy item-chip--accuracy-${accuracyVariant}`}
+                                title={sessionAccuracy !== null ? 'Baseado nas sessões registradas' : 'Definido manualmente'}
+                              >
+                                {displayAccuracy}% acerto
+                                {sessionAccuracy !== null && (
+                                  <span className="item-chip__note">auto</span>
+                                )}
                               </span>
+                            )}
 
-                            <div className="item-stats" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            {(() => {
-                              // Priorizar percentual de acerto das sessões, depois o manual
-                              const sessionAccuracy = getItemAccuracyFromSessions(item.id);
-                              const displayAccuracy = sessionAccuracy !== null ? sessionAccuracy : item.accuracy;
+                            {item.weight !== undefined && (
+                              <span className="item-chip item-chip--weight">Peso {item.weight}%</span>
+                            )}
 
-                              return displayAccuracy !== undefined && (
-                                <div
-                                  className="accuracy-triangle"
-                                  style={{
-                                    backgroundColor: getAccuracyColor(displayAccuracy),
-                                    color: 'white',
-                                    padding: '2px 6px',
-                                    borderRadius: '4px',
-                                    fontSize: '0.7rem',
-                                    fontWeight: 'bold',
-                                    marginRight: '8px'
-                                  }}
-                                  title={sessionAccuracy !== null ? 'Baseado nas sessões de estudo' : 'Definido manualmente'}
+                            {reviewStatus && (
+                              <span className={`item-chip item-chip--review item-chip--review-${reviewStatus.variant}`}>
+                                Revisão {reviewStatus.label.toLowerCase()}
+                              </span>
+                            )}
+
+                            {!item.isStudied && (
+                              <span className="item-chip item-chip--status">Ainda não estudado</span>
+                            )}
+                          </div>
+
+                          {editingItem === item.id && (
+                            <div className="syllabus-item-card__editor">
+                              <div className="editor-field">
+                                <label htmlFor={`accuracy-${item.id}`}>% de acerto</label>
+                                <input
+                                  id={`accuracy-${item.id}`}
+                                  type="number"
+                                  value={tempAccuracy}
+                                  onChange={(e) => setTempAccuracy(e.target.value)}
+                                  className="editor-input"
+                                  min="0"
+                                  max="100"
+                                  placeholder="0-100"
+                                />
+                              </div>
+
+                              <div className="editor-field">
+                                <label htmlFor={`weight-${item.id}`}>Peso no edital</label>
+                                <input
+                                  id={`weight-${item.id}`}
+                                  type="number"
+                                  value={tempWeight}
+                                  onChange={(e) => setTempWeight(e.target.value)}
+                                  className="editor-input"
+                                  min="0"
+                                  max="100"
+                                  placeholder="0-100"
+                                />
+                              </div>
+
+                              <div className="editor-actions">
+                                <button
+                                  className="editor-btn editor-btn--primary"
+                                  onClick={() => handleSaveAccuracy(item.id)}
+                                  disabled={!tempAccuracy}
+                                  type="button"
                                 >
-                                  {displayAccuracy}%
-                                </div>
-                              );
-                            })()}
-
-                              {item.weight !== undefined && (
-                                <div
-                                  style={{
-                                    fontSize: '0.7rem',
-                                    color: '#94a3b8'
-                                  }}
+                                  Salvar % acerto
+                                </button>
+                                <button
+                                  className="editor-btn editor-btn--success"
+                                  onClick={() => handleSaveWeight(item.id)}
+                                  disabled={!tempWeight}
+                                  type="button"
                                 >
-                                  Peso: {item.weight}%
-                                </div>
-                              )}
+                                  Salvar peso
+                                </button>
+                                <button
+                                  className="editor-btn editor-btn--ghost"
+                                  onClick={() => {
+                                    setEditingItem(null);
+                                    setTempAccuracy('');
+                                    setTempWeight('');
+                                  }}
+                                  type="button"
+                                >
+                                  Cancelar
+                                </button>
+                              </div>
                             </div>
-                          </div>
-
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <button
-                              className="details-btn"
-                              onClick={() => {
-                                setSelectedSyllabusItem(item);
-                                setIsItemDetailsModalOpen(true);
-                              }}
-                              title="Histórico de Item"
-                            >
-                              <Eye size={12} />
-                            </button>
-
-                            <button
-                              className="details-btn"
-                              onClick={() => {
-                                setEditingItem(item.id);
-                                setTempAccuracy(item.accuracy?.toString() || '');
-                                setTempWeight(item.weight?.toString() || '');
-                              }}
-                              title="Editar % Acerto e Peso"
-                            >
-                              <Edit2 size={12} />
-                            </button>
-                          </div>
+                          )}
                         </div>
-
-                        {editingItem === item.id && (
-                          <div className="edit-controls" style={{
-                            marginTop: '8px',
-                            padding: '8px',
-                            background: 'rgba(15, 23, 42, 0.8)',
-                            borderRadius: '6px',
-                            display: 'flex',
-                            gap: '8px',
-                            alignItems: 'center',
-                            flexWrap: 'wrap'
-                          }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                              <label style={{ fontSize: '0.8rem', color: '#cbd5e1' }}>% Acerto:</label>
-                              <input
-                                type="number"
-                                value={tempAccuracy}
-                                onChange={(e) => setTempAccuracy(e.target.value)}
-                                className="accuracy-input"
-                                style={{ width: '60px' }}
-                                min="0"
-                                max="100"
-                                placeholder="0-100"
-                              />
-                            </div>
-
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                              <label style={{ fontSize: '0.8rem', color: '#cbd5e1' }}>% Peso:</label>
-                              <input
-                                type="number"
-                                value={tempWeight}
-                                onChange={(e) => setTempWeight(e.target.value)}
-                                className="accuracy-input"
-                                style={{ width: '60px' }}
-                                min="0"
-                                max="100"
-                                placeholder="0-100"
-                              />
-                            </div>
-
-                            <button
-                              className="save-btn"
-                              onClick={() => handleSaveAccuracy(item.id)}
-                              style={{ fontSize: '0.7rem', padding: '4px 8px' }}
-                              disabled={!tempAccuracy}
-                            >
-                              Salvar %
-                            </button>
-
-                            <button
-                              className="save-btn"
-                              onClick={() => handleSaveWeight(item.id)}
-                              style={{ fontSize: '0.7rem', padding: '4px 8px', background: '#059669' }}
-                              disabled={!tempWeight}
-                            >
-                              Salvar Peso
-                            </button>
-
-                            <button
-                              className="save-btn"
-                              onClick={() => {
-                                setEditingItem(null);
-                                setTempAccuracy('');
-                                setTempWeight('');
-                              }}
-                              style={{
-                                fontSize: '0.7rem',
-                                padding: '4px 8px',
-                                background: '#6b7280'
-                              }}
-                            >
-                              Cancelar
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    );
-                    })}
-                  </div>
-                )}
+                      );
+                    })
+                  )}
+                </div>
               </div>
             )}
-          </div>
+          </article>
         );
       })}
     </div>

--- a/src/components/dashboard/ExperienceNavigator.jsx
+++ b/src/components/dashboard/ExperienceNavigator.jsx
@@ -1,0 +1,658 @@
+import React, { useMemo, useState } from 'react';
+import {
+  LayoutDashboard,
+  CalendarRange,
+  RefreshCw,
+  Timer,
+  BarChart3,
+  MapPin,
+  ScrollText,
+  Cog,
+  WifiOff,
+  MonitorSmartphone,
+  CalendarClock,
+  Target,
+  TrendingUp
+} from 'lucide-react';
+
+const formatHours = (value) => {
+  if (!value || Number.isNaN(value)) {
+    return '0h';
+  }
+  if (value < 1) {
+    return `${Math.round(value * 60)}min`;
+  }
+  return `${value.toFixed(1)}h`;
+};
+
+const formatPercentage = (value) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  return `${Math.round(value)}%`;
+};
+
+export const ExperienceNavigator = ({
+  activeProfile,
+  subjects,
+  sessions,
+  syllabusItems,
+  simulados,
+  urgentReviewItems,
+  upcomingSessions,
+  upcomingSimulados,
+  nextReviewLabel,
+  totalHoursStudied,
+  studiedPercentage
+}) => {
+  const [activeTab, setActiveTab] = useState('dashboard');
+
+  const {
+    averageDailyHours,
+    streakDays,
+    sessionsBySubject,
+    accuracyAverage
+  } = useMemo(() => {
+    if (!sessions || sessions.length === 0) {
+      return {
+        averageDailyHours: 0,
+        streakDays: 0,
+        sessionsBySubject: new Map(),
+        accuracyAverage: null
+      };
+    }
+
+    const totalsByDay = new Map();
+    const totalsBySubject = new Map();
+    const accuracyValues = [];
+
+    sessions.forEach((session) => {
+      if (session.date) {
+        const dayKey = session.date;
+        totalsByDay.set(dayKey, (totalsByDay.get(dayKey) || 0) + (session.duration || 0));
+      }
+
+      if (session.subjectId) {
+        totalsBySubject.set(session.subjectId, (totalsBySubject.get(session.subjectId) || 0) + (session.duration || 0));
+      }
+
+      if (session.accuracy !== undefined && session.accuracy !== null) {
+        accuracyValues.push(session.accuracy);
+      }
+    });
+
+    const totalMinutes = Array.from(totalsByDay.values()).reduce((sum, value) => sum + value, 0);
+    const averageDailyHours = totalMinutes / Math.max(totalsByDay.size, 1) / 60;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    let streakDays = 0;
+    for (let offset = 0; offset < 30; offset += 1) {
+      const checkDate = new Date(today);
+      checkDate.setDate(today.getDate() - offset);
+      const iso = checkDate.toISOString().split('T')[0];
+      if (totalsByDay.has(iso)) {
+        streakDays += 1;
+      } else {
+        break;
+      }
+    }
+
+    const accuracyAverage = accuracyValues.length
+      ? accuracyValues.reduce((sum, value) => sum + value, 0) / accuracyValues.length
+      : null;
+
+    return {
+      averageDailyHours,
+      streakDays,
+      sessionsBySubject: totalsBySubject,
+      accuracyAverage
+    };
+  }, [sessions]);
+
+  const {
+    targetHours,
+    topSubjects,
+    reviewCoverage,
+    dominatedTopics,
+    focusTopics
+  } = useMemo(() => {
+    const totalTarget = subjects.reduce((sum, subject) => sum + (Number(subject.targetHours) || 0), 0);
+
+    const subjectBreakdown = subjects.map((subject) => {
+      const planned = Number(subject.targetHours) || 0;
+      const executedMinutes = sessionsBySubject.get(subject.id) || 0;
+      return {
+        id: subject.id,
+        name: subject.name,
+        planned,
+        executed: executedMinutes / 60
+      };
+    });
+
+    const topSubjects = subjectBreakdown
+      .filter((entry) => entry.planned > 0 || entry.executed > 0)
+      .sort((a, b) => b.executed - a.executed)
+      .slice(0, 3);
+
+    const totalItems = syllabusItems.length;
+    const scheduledReviews = syllabusItems.filter((item) => item.nextReviewDate).length;
+    const reviewCoverage = totalItems > 0 ? (scheduledReviews / totalItems) * 100 : null;
+
+    const dominatedTopics = syllabusItems.filter((item) => (item.accuracy || 0) >= 85).length;
+    const focusTopics = syllabusItems.filter((item) => item.isStudied && (item.accuracy || 0) < 85).length;
+
+    return {
+      targetHours: totalTarget,
+      topSubjects,
+      reviewCoverage,
+      dominatedTopics,
+      focusTopics
+    };
+  }, [subjects, sessionsBySubject, syllabusItems]);
+
+  const totalUpcomingSessions = upcomingSessions?.length || 0;
+  const totalRevisoesPendentes = urgentReviewItems?.length || 0;
+  const totalSimulados = simulados?.length || 0;
+  const upcomingSimuladosCount = upcomingSimulados?.length || 0;
+
+  const tabs = useMemo(
+    () => [
+      {
+        id: 'dashboard',
+        label: 'Dashboard',
+        badge: 'Visão diária',
+        icon: LayoutDashboard,
+        summary: 'Rotina sem atritos',
+        description:
+          'Acompanhe calendário, blocos agendados e alertas de revisão em um só lugar. O painel inicial conecta seus indicadores principais com ações rápidas para registrar sessões, abrir revisões ou importar novos editais.',
+        metrics: [
+          {
+            label: 'Horas acumuladas',
+            value: formatHours(totalHoursStudied),
+            helper: 'tempo registrado no ciclo ativo'
+          },
+          {
+            label: 'Cadência diária',
+            value: formatHours(averageDailyHours),
+            helper: streakDays > 0 ? `${streakDays} dia(s) consecutivos` : 'sem sequência ativa'
+          },
+          {
+            label: 'Blocos planejados',
+            value: totalUpcomingSessions,
+            helper: 'sessões futuras com duração definida'
+          }
+        ],
+        highlights: [
+          'Calendário unificado do dia com próximas sessões e revisões pendentes.',
+          'Alertas de produtividade destacam atrasos em metas diárias.',
+          'Atalhos para abrir cronômetro, registrar bloco ou ajustar o ciclo.'
+        ],
+        actions: [
+          {
+            icon: CalendarClock,
+            title: 'Reveja sua agenda da semana',
+            description: 'Arraste sessões na linha do tempo para manter o plano realista.'
+          },
+          {
+            icon: TrendingUp,
+            title: 'Ative o resumo inteligente',
+            description: 'Combine progresso do edital com revisões críticas na abertura do app.'
+          }
+        ]
+      },
+      {
+        id: 'cycle',
+        label: 'Ciclo de Estudos',
+        badge: 'Planejamento',
+        icon: CalendarRange,
+        summary: 'Carga flexível e adaptável',
+        description:
+          'Monte ciclos realistas distribuindo horas por disciplina e ajuste automaticamente quando sua rotina muda. O Estudei sugere redistribuições sempre que você fica abaixo da meta diária.',
+        metrics: [
+          {
+            label: 'Carga semanal planejada',
+            value: targetHours > 0 ? `${targetHours}h` : 'Defina metas',
+            helper: 'soma das horas alvo das matérias'
+          },
+          {
+            label: 'Top disciplinas',
+            value: topSubjects.length > 0 ? topSubjects.map((item) => item.name).join(', ') : 'Defina prioridades',
+            helper: 'maior dedicação na semana'
+          },
+          {
+            label: 'Blocos futuros',
+            value: totalUpcomingSessions,
+            helper: 'sessões agendadas a partir de hoje'
+          }
+        ],
+        highlights: [
+          'Distribuição automática de horas ao longo da semana com base na sua disponibilidade.',
+          'Sugestões de ajuste quando uma meta diária não é atingida.',
+          'Permite reorganizar a ordem das disciplinas por prioridade.'
+        ],
+        actions: [
+          {
+            icon: CalendarRange,
+            title: 'Reequilibre a carga da semana',
+            description: 'Use o ajuste automático para recuperar horas não cumpridas.'
+          }
+        ]
+      },
+      {
+        id: 'reviews',
+        label: 'Revisões',
+        badge: 'Repetição espaçada',
+        icon: RefreshCw,
+        summary: 'Memória sob controle',
+        description:
+          'A agenda de revisões aplica espaçamentos inteligentes para você revisar no momento certo. Receba lembretes e ajuste intervalos conforme acurácia e dificuldade de cada tópico.',
+        metrics: [
+          {
+            label: 'Pendências',
+            value: totalRevisoesPendentes,
+            helper: 'itens aguardando revisão hoje'
+          },
+          {
+            label: 'Cobertura do edital',
+            value: formatPercentage(reviewCoverage),
+            helper: 'itens com revisão agendada'
+          },
+          {
+            label: 'Próxima revisão',
+            value: nextReviewLabel || '—',
+            helper: 'data sugerida pelo algoritmo'
+          }
+        ],
+        highlights: [
+          'Lembretes automáticos quando uma revisão fica atrasada.',
+          'Intervalos recomendados com base no percentual de acerto.',
+          'Controle visual das revisões concluídas e pendentes por matéria.'
+        ],
+        actions: [
+          {
+            icon: RefreshCw,
+            title: 'Ajuste os espaçamentos',
+            description: 'Personalize os ciclos (1, 3, 7, 15, 30 dias) conforme sua retenção.'
+          }
+        ]
+      },
+      {
+        id: 'records',
+        label: 'Registro de Estudos',
+        badge: 'Diário inteligente',
+        icon: Timer,
+        summary: 'Tudo que você fez, em um só lugar',
+        description:
+          'Registre horas, páginas lidas, videoaulas, questões e resumos com o cronômetro integrado. Classifique por disciplina, material e tipo de contato para alimentar seus indicadores automaticamente.',
+        metrics: [
+          {
+            label: 'Sessões registradas',
+            value: sessions.length,
+            helper: 'entradas no período atual'
+          },
+          {
+            label: 'Horas registradas',
+            value: formatHours(totalHoursStudied),
+            helper: 'considerando todos os blocos'
+          },
+          {
+            label: 'Acurácia média',
+            value: formatPercentage(accuracyAverage),
+            helper: 'baseado nos blocos com questões'
+          }
+        ],
+        highlights: [
+          'Cronômetro integrado para medir tempo real da sessão.',
+          'Classificação por tipo de material e forma de estudo (primeiro contato ou revisão).',
+          'Integração direta com a aba Estatísticas e mapa de dificuldades.'
+        ],
+        actions: [
+          {
+            icon: Timer,
+            title: 'Ative o timer instantâneo',
+            description: 'Comece a contagem direto do dashboard para não perder minutos.'
+          }
+        ]
+      },
+      {
+        id: 'analytics',
+        label: 'Indicadores',
+        badge: 'Estatísticas',
+        icon: BarChart3,
+        summary: 'Progresso com dados acionáveis',
+        description:
+          'Gráficos e indicadores mostram consistência, evolução por disciplina e desempenho em simulados. Identifique quedas de produtividade e ajuste o plano com base em dados reais.',
+        metrics: [
+          {
+            label: 'Progresso do edital',
+            value: formatPercentage(studiedPercentage),
+            helper: 'itens marcados como estudados'
+          },
+          {
+            label: 'Simulados agendados',
+            value: upcomingSimuladosCount,
+            helper: totalSimulados > 0 ? `${totalSimulados} já realizados` : 'comece registrando um simulado'
+          },
+          {
+            label: 'Acurácia média',
+            value: formatPercentage(accuracyAverage),
+            helper: 'questões registradas'
+          }
+        ],
+        highlights: [
+          'Gráficos de evolução temporal de horas e desempenho.',
+          'Distribuição de tempo por disciplina e tipo de material.',
+          'Percentual de acerto e dificuldade em simulados para guiar ajustes.'
+        ],
+        actions: [
+          {
+            icon: Target,
+            title: 'Analise seus simulados',
+            description: 'Identifique quedas de acerto e crie revisões específicas.'
+          }
+        ]
+      },
+      {
+        id: 'map',
+        label: 'Mapa de Dificuldades',
+        badge: 'Prioridades',
+        icon: MapPin,
+        summary: 'Veja onde acelerar ou revisar',
+        description:
+          'Classifique tópicos como dominados, em andamento ou pendentes para visualizar rapidamente quais conteúdos precisam de reforço. O mapa usa seus registros e acurácia para priorizar revisões.',
+        metrics: [
+          {
+            label: 'Dominados',
+            value: dominatedTopics,
+            helper: 'acurácia ≥ 85%'
+          },
+          {
+            label: 'Em foco',
+            value: focusTopics,
+            helper: 'precisam de reforço'
+          },
+          {
+            label: 'A iniciar',
+            value: Math.max(syllabusItems.length - (dominatedTopics + focusTopics), 0),
+            helper: 'ainda sem estudo registrado'
+          }
+        ],
+        highlights: [
+          'Marcações rápidas (dominado, estudado, não estudado).',
+          'Integração com percentuais de acerto para priorização automática.',
+          'Sugestões de reforço para tópicos críticos.'
+        ],
+        actions: [
+          {
+            icon: MapPin,
+            title: 'Revise o mapa semanalmente',
+            description: 'Reclassifique tópicos após cada simulado ou revisão importante.'
+          }
+        ]
+      },
+      {
+        id: 'edital',
+        label: 'Edital Verticalizado',
+        badge: 'Conteúdo',
+        icon: ScrollText,
+        summary: 'Controle total do edital',
+        description:
+          'Visualize o edital em formato hierárquico, marque itens concluídos e acompanhe a porcentagem estudada. Ideal para garantir que nenhum tópico fique para trás antes da prova.',
+        metrics: [
+          {
+            label: 'Itens mapeados',
+            value: syllabusItems.length,
+            helper: 'total importado ou criado'
+          },
+          {
+            label: 'Itens estudados',
+            value: Math.round((studiedPercentage / 100) * syllabusItems.length) || 0,
+            helper: 'concluídos no edital'
+          },
+          {
+            label: 'Cobertura geral',
+            value: formatPercentage(studiedPercentage),
+            helper: 'progresso total'
+          }
+        ],
+        highlights: [
+          'Estrutura hierárquica para navegar por temas e subtemas.',
+          'Marcação rápida de status e peso de cada item.',
+          'Importação de editais oficiais com poucos cliques.'
+        ],
+        actions: [
+          {
+            icon: ScrollText,
+            title: 'Sincronize com o edital oficial',
+            description: 'Use a biblioteca de editais globais para começar com base atualizada.'
+          }
+        ]
+      },
+      {
+        id: 'settings',
+        label: 'Configurações',
+        badge: 'Personalização',
+        icon: Cog,
+        summary: 'Seu ambiente, do seu jeito',
+        description:
+          'Ajuste metas, duração padrão dos blocos, ordem das disciplinas, temas claro/escuro e notificações push. Customize o aplicativo para o seu ritmo de estudos.',
+        metrics: [
+          {
+            label: 'Concursos ativos',
+            value: activeProfile ? 1 : 0,
+            helper: activeProfile ? activeProfile.name : 'Crie seu primeiro perfil'
+          },
+          {
+            label: 'Disciplinas cadastradas',
+            value: subjects.length,
+            helper: 'organizadas no ciclo atual'
+          },
+          {
+            label: 'Notificações',
+            value: 'Push e e-mail',
+            helper: 'personalize lembretes de estudo'
+          }
+        ],
+        highlights: [
+          'Temas claro e escuro para estudar com conforto visual.',
+          'Configuração das metas diárias e semanais de estudo.',
+          'Controle sobre a ordem das disciplinas e duração dos blocos.'
+        ],
+        actions: [
+          {
+            icon: Cog,
+            title: 'Revise suas metas mensais',
+            description: 'Atualize metas de horas sempre que o edital mudar de fase.'
+          }
+        ]
+      },
+      {
+        id: 'offline',
+        label: 'Modo Offline',
+        badge: 'Sem internet',
+        icon: WifiOff,
+        summary: 'Continue estudando em qualquer lugar',
+        description:
+          'Registre blocos e revise conteúdos mesmo sem conexão. Assim que o aparelho voltar à internet, o Estudei sincroniza automaticamente seus dados com a nuvem.',
+        metrics: [
+          {
+            label: 'Sincronizações pendentes',
+            value: 'Automáticas',
+            helper: 'fila enviada ao reconectar'
+          },
+          {
+            label: 'Backup',
+            value: 'Nuvem segura',
+            helper: 'acesso web garantido'
+          },
+          {
+            label: 'Privacidade',
+            value: 'Dados privados',
+            helper: 'sem compartilhamento com terceiros'
+          }
+        ],
+        highlights: [
+          'Funciona mesmo sem conexão constante.',
+          'Fila de sincronização automática após reconectar.',
+          'Dados protegidos sem compartilhamento com terceiros.'
+        ],
+        actions: [
+          {
+            icon: WifiOff,
+            title: 'Planeje viagens ou deslocamentos',
+            description: 'Baixe materiais e mantenha o registro de estudos sem depender da rede.'
+          }
+        ]
+      },
+      {
+        id: 'platforms',
+        label: 'Plataformas',
+        badge: 'Web • iOS • Android',
+        icon: MonitorSmartphone,
+        summary: 'Experiência fluida em todos os dispositivos',
+        description:
+          'O Estudei está disponível na web, Android e iOS. Seu progresso é sincronizado entre plataformas para que você continue exatamente de onde parou, seja no computador ou no celular.',
+        metrics: [
+          {
+            label: 'Aplicativos móveis',
+            value: 'iOS e Android',
+            helper: 'interface otimizada por gestos'
+          },
+          {
+            label: 'Versão web',
+            value: 'Completa',
+            helper: 'ideal para análises detalhadas'
+          },
+          {
+            label: 'Sincronização',
+            value: 'Tempo quase real',
+            helper: 'dados unificados na nuvem'
+          }
+        ],
+        highlights: [
+          'Apps nativos lançados para iOS e Android com gestos otimizados.',
+          'Interface responsiva adaptada a telas menores.',
+          'Continuidade total do estudo entre web e mobile.'
+        ],
+        actions: [
+          {
+            icon: MonitorSmartphone,
+            title: 'Instale o app no seu dispositivo',
+            description: 'Acesse a loja oficial e sincronize com a sua conta Estudei.'
+          }
+        ]
+      }
+    ],
+    [
+      totalHoursStudied,
+      averageDailyHours,
+      streakDays,
+      totalUpcomingSessions,
+      targetHours,
+      topSubjects,
+      totalRevisoesPendentes,
+      reviewCoverage,
+      nextReviewLabel,
+      accuracyAverage,
+      totalSimulados,
+      studiedPercentage,
+      syllabusItems.length,
+      dominatedTopics,
+      focusTopics,
+      activeProfile,
+      subjects.length,
+      upcomingSimuladosCount
+    ]
+  );
+
+  const activeContent = tabs.find((tab) => tab.id === activeTab) || tabs[0];
+
+  return (
+    <div className="card experience-showcase">
+      <header className="experience-showcase__header">
+        <div>
+          <span className="experience-showcase__eyebrow">Jornada Estudei</span>
+          <h3 className="experience-showcase__title">Domine cada etapa do seu preparo</h3>
+          <p className="experience-showcase__subtitle">
+            Explore as páginas do aplicativo e veja como cada uma contribui para um estudo organizado, com dados, revisões e sincronização contínua.
+          </p>
+        </div>
+        {activeProfile && (
+          <div className="experience-showcase__profile">
+            <span className="experience-chip">Concurso ativo</span>
+            <strong>{activeProfile.name}</strong>
+            {activeProfile.examDate && (
+              <span className="experience-showcase__profile-date">
+                Prova em {new Date(activeProfile.examDate).toLocaleDateString('pt-BR')}
+              </span>
+            )}
+          </div>
+        )}
+      </header>
+
+      <div className="experience-tabs" role="tablist" aria-label="Páginas do aplicativo">
+        {tabs.map(({ id, label, icon: Icon, badge }) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === id}
+            className={`experience-tab ${activeTab === id ? 'experience-tab--active' : ''}`}
+            onClick={() => setActiveTab(id)}
+          >
+            <span className="experience-tab__icon">
+              <Icon size={16} />
+            </span>
+            <span className="experience-tab__content">
+              <span className="experience-tab__label">{label}</span>
+              <span className="experience-tab__badge">{badge}</span>
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <section className="experience-panel" role="tabpanel">
+        <header className="experience-panel__header">
+          <div>
+            <span className="experience-panel__badge">{activeContent.badge}</span>
+            <h4 className="experience-panel__title">{activeContent.summary}</h4>
+          </div>
+        </header>
+        <p className="experience-panel__description">{activeContent.description}</p>
+
+        <div className="experience-metrics">
+          {activeContent.metrics.map((metric) => (
+            <div key={metric.label} className="experience-metric">
+              <span className="experience-metric__value">{metric.value}</span>
+              <span className="experience-metric__label">{metric.label}</span>
+              <span className="experience-metric__helper">{metric.helper}</span>
+            </div>
+          ))}
+        </div>
+
+        <ul className="experience-callouts">
+          {activeContent.highlights.map((highlight) => (
+            <li key={highlight}>{highlight}</li>
+          ))}
+        </ul>
+
+        <div className="experience-actions">
+          {activeContent.actions.map((action) => (
+            <div key={action.title} className="experience-action">
+              <div className="experience-action__icon">
+                <action.icon size={16} />
+              </div>
+              <div>
+                <p className="experience-action__title">{action.title}</p>
+                <p className="experience-action__description">{action.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ExperienceNavigator;

--- a/src/components/dashboard/GlobalConcursosCard.jsx
+++ b/src/components/dashboard/GlobalConcursosCard.jsx
@@ -2,24 +2,67 @@ import React from 'react';
 
 export default function GlobalConcursosCard({ concursos, syllabusItems, onImport }) {
   if (!concursos || concursos.length === 0) return null;
+
   return (
-    <div className="card">
-      <h2>Concursos Globais</h2>
+    <div className="card space-y-4 p-6 sm:p-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <span className="text-xs uppercase tracking-wide text-slate-300">Biblioteca global</span>
+          <h2 className="mt-1 text-xl font-semibold text-white">Concursos sugeridos</h2>
+          <p className="mt-2 text-sm text-slate-400">
+            Importe rapidamente editais completos estruturados por especialistas.
+          </p>
+        </div>
+        <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-200">
+          {concursos.length} disponíveis
+        </span>
+      </div>
+
       <div className="space-y-3">
-        {concursos.map(c => {
-          const totalSubtopicos = (c.materias||[]).reduce((acc,m)=> acc + (m.submaterias||[]).reduce((a,s)=> a + (s.subtopicos||[]).length,0),0);
-          const importedCount = syllabusItems.filter(i=> i.concursoId===c.id).length;
-          const pct = totalSubtopicos>0? ((importedCount/totalSubtopicos)*100).toFixed(1):'0';
+        {concursos.map(concurso => {
+          const totalSubtopicos = (concurso.materias || []).reduce(
+            (acc, materia) =>
+              acc + (materia.submaterias || []).reduce(
+                (subAcc, submateria) => subAcc + (submateria.subtopicos || []).length,
+                0
+              ),
+            0
+          );
+          const importedCount = syllabusItems.filter(item => item.concursoId === concurso.id).length;
+          const progress = totalSubtopicos > 0 ? ((importedCount / totalSubtopicos) * 100).toFixed(1) : '0';
+
           return (
-            <div key={c.id} className="p-3 border rounded bg-white shadow-sm">
-              <div className="flex items-center justify-between mb-1">
-                <div className="font-semibold text-sm text-slate-800">{c.nome}</div>
-                <button className="btn btn-secondary !py-1 !px-2 text-xs" onClick={()=>onImport(c.id)}>Importar</button>
+            <div
+              key={concurso.id}
+              className="rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-sky-400/40"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-white">{concurso.nome}</p>
+                  {concurso.banca && <p className="text-xs text-slate-400">Banca: {concurso.banca}</p>}
+                  {concurso.orgao && <p className="text-xs text-slate-500">{concurso.orgao}</p>}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onImport(concurso.id)}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/10"
+                >
+                  Importar
+                </button>
               </div>
-              <div className="text-[11px] text-slate-500 mb-1">{importedCount}/{totalSubtopicos} subtópicos ({pct}%)</div>
-              <div className="w-full h-2 bg-slate-200 rounded">
-                <div className="h-2 bg-indigo-600 rounded" style={{width: pct+'%'}}></div>
+
+              <div className="mt-3 flex items-center gap-3 text-xs text-slate-300">
+                <div className="h-2 flex-1 rounded-full bg-slate-800">
+                  <div
+                    className="h-2 rounded-full bg-sky-500"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+                <span className="font-semibold text-slate-200">{progress}%</span>
               </div>
+              <p className="mt-2 text-[11px] text-slate-400">
+                {importedCount}/{totalSubtopicos} subtópicos importados
+              </p>
             </div>
           );
         })}

--- a/src/index.css
+++ b/src/index.css
@@ -69,6 +69,92 @@
 
 /* Component styles */
 @layer components {
+  .app-shell {
+    position: relative;
+    min-height: 100vh;
+    background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 55%), #020617;
+    color: #e2e8f0;
+    overflow-x: hidden;
+  }
+
+  .app-shell__gradient,
+  .app-shell__grid,
+  .app-shell__blur {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .app-shell__gradient {
+    background: radial-gradient(circle at top, rgba(37, 99, 235, 0.18), transparent 60%),
+      radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.08), transparent 60%);
+    opacity: 0.95;
+  }
+
+  .app-shell__grid {
+    background-image:
+      linear-gradient(0deg, rgba(148, 163, 184, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(148, 163, 184, 0.04) 1px, transparent 1px);
+    background-size: 40px 40px;
+    mix-blend-mode: lighten;
+    opacity: 0.45;
+  }
+
+  .app-shell__blur {
+    border-radius: 9999px;
+    filter: blur(120px);
+    opacity: 0.7;
+  }
+
+  .app-shell__blur--1 {
+    top: -160px;
+    left: -120px;
+    width: 380px;
+    height: 380px;
+    background: rgba(91, 33, 182, 0.32);
+  }
+
+  .app-shell__blur--2 {
+    bottom: -140px;
+    right: -100px;
+    width: 320px;
+    height: 320px;
+    background: rgba(56, 189, 248, 0.28);
+  }
+
+  .app-shell__content {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 6rem;
+  }
+
+  .loading-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .loading-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .loading-message {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #f1f5f9;
+  }
+
+  .loading-subtext {
+    font-size: 0.85rem;
+    color: rgba(148, 163, 184, 0.85);
+  }
+
   /* Button base styles - Modern Design */
   .btn {
     display: inline-flex;
@@ -140,28 +226,22 @@
   
   /* Card styles - Modern Design */
   .card {
-    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 41, 59, 0.95) 100%);
-    border-radius: 16px;
-    box-shadow:
-      0 20px 25px -5px rgba(0, 0, 0, 0.3),
-      0 10px 10px -5px rgba(0, 0, 0, 0.1),
-      inset 0 1px 0 rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(20px);
-    padding: 16px;
-    margin-bottom: 16px;
     position: relative;
+    background: linear-gradient(155deg, rgba(15, 23, 42, 0.86) 0%, rgba(2, 6, 23, 0.92) 100%);
+    border-radius: 22px;
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    box-shadow: 0 32px 55px -35px rgba(15, 23, 42, 0.85);
+    backdrop-filter: blur(18px);
+    padding: 24px;
     overflow: hidden;
   }
 
   .card::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.05) 0%, transparent 100%);
+    inset: 0;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), transparent 65%);
+    opacity: 0.6;
     pointer-events: none;
   }
   
@@ -281,24 +361,55 @@
 }
 
 .stat-card {
-  background: rgba(30, 41, 59, 0.9);
-  border-radius: 6px;
-  padding: 12px;
-  border: 1px solid rgba(71, 85, 105, 0.3);
-  text-align: center;
-  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.1), rgba(15, 23, 42, 0.35));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: 18px;
+  text-align: left;
+  backdrop-filter: blur(16px);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.35);
+  box-shadow: 0 26px 45px -30px rgba(56, 189, 248, 0.55);
+}
+
+.modern-stat {
+  min-height: 150px;
 }
 
 .stat-value {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #3b82f6;
-  margin-bottom: 4px;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #f8fafc;
 }
 
 .stat-label {
-  color: #94a3b8;
-  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.subject-card {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 28px 50px -35px rgba(15, 23, 42, 0.7);
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.subject-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.4);
+  box-shadow: 0 30px 55px -32px rgba(59, 130, 246, 0.45);
 }
 
 /* Subjects overview */
@@ -402,218 +513,524 @@
   font-size: 0.75rem;
 }
 
-/* Nova Visão Geral das Matérias */
-.subjects-overview-new {
+/* Visão geral das matérias */
+.subjects-overview {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1.5rem;
 }
 
-.subject-overview-new {
-  background: rgba(30, 41, 59, 0.9);
-  border-radius: 12px;
-  border: 1px solid rgba(71, 85, 105, 0.3);
+.subject-card {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.94), rgba(15, 23, 42, 0.78));
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 1.5rem;
+  box-shadow: 0 24px 45px -32px rgba(15, 23, 42, 0.85);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.subject-card--expanded {
+  border-color: rgba(56, 189, 248, 0.35);
+  box-shadow: 0 28px 55px -30px rgba(56, 189, 248, 0.45);
+  transform: translateY(-2px);
+}
+
+.subject-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.subject-card__title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.subject-card__title {
+  margin: 0 0 0.35rem 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.subject-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.subject-card__meta-pill {
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.9);
+  border-radius: 9999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.subject-card__toggle {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  color: #cbd5f5;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.subject-card__toggle:hover {
+  border-color: rgba(125, 211, 252, 0.4);
+  color: #e0f2fe;
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.12);
+}
+
+.subject-card__insights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.subject-card__progress {
+  flex: 1;
+  min-width: 220px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.subject-card__progress-track {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
   overflow: hidden;
 }
 
-.subject-header-new {
+.subject-card__progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+  border-radius: inherit;
+  transition: width 0.35s ease;
+}
+
+.subject-card__progress-meta {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  padding: 16px 20px;
-  background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
-  color: white;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.85);
 }
 
-.subject-info h3.subject-name {
-  margin: 0 0 4px 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.subject-stats-inline {
-  display: flex;
-  gap: 8px;
-  font-size: 0.85rem;
-  opacity: 0.9;
-}
-
-.subject-controls {
+.subject-card__next-review {
   display: flex;
   align-items: center;
-  gap: 12px;
-}
-
-.filter-tabs {
-  display: flex;
-  gap: 4px;
-}
-
-.filter-tab {
-  padding: 4px 12px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  gap: 0.75rem;
+  min-width: 220px;
+  padding: 0.9rem 1rem;
   border-radius: 16px;
-  color: white;
-  font-size: 0.8rem;
-  cursor: pointer;
-  transition: all 0.2s ease;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.92);
 }
 
-.filter-tab.active {
-  background: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.4);
+.subject-card__next-review--overdue {
+  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.12);
+  color: #fecdd3;
 }
 
-.filter-tab:hover {
-  background: rgba(255, 255, 255, 0.15);
+.subject-card__next-review--today {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.12);
+  color: #bae6fd;
 }
 
-.expand-btn {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 6px;
-  color: white;
-  padding: 4px;
-  cursor: pointer;
-  transition: all 0.2s ease;
+.subject-card__next-review--soon {
+  border-color: rgba(96, 165, 250, 0.35);
+  background: rgba(96, 165, 250, 0.12);
+  color: #c7d2fe;
 }
 
-.expand-btn:hover {
-  background: rgba(255, 255, 255, 0.2);
+.subject-card__next-review--upcoming {
+  border-color: rgba(125, 211, 252, 0.3);
+  background: rgba(125, 211, 252, 0.12);
+  color: #e0f2fe;
 }
 
-.subject-content-new {
-  padding: 20px;
+.subject-card__next-review--empty {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.75);
 }
 
-.no-items {
-  text-align: center;
-  color: #64748b;
-  font-style: italic;
-  padding: 20px;
-}
-
-.syllabus-items-list {
+.subject-card__next-review-text {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.1rem;
 }
 
-.syllabus-item-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 4px 8px;
-  background: rgba(71, 85, 105, 0.2);
-  border-radius: 6px;
-  border: 1px solid rgba(71, 85, 105, 0.3);
-}
-
-.item-content {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex: 1;
-}
-
-.item-name {
-  color: #e2e8f0;
-  font-size: 0.9rem;
-}
-
-.item-stats {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.accuracy-badge {
-  background: #10b981;
-  color: white;
-  padding: 2px 8px;
-  border-radius: 12px;
-  font-size: 0.8rem;
+.subject-card__next-review-text .value {
+  font-size: 0.85rem;
   font-weight: 600;
 }
 
-.details-btn {
-  background: rgba(59, 130, 246, 0.2);
-  border: 1px solid rgba(59, 130, 246, 0.4);
-  border-radius: 4px;
-  color: #60a5fa;
-  padding: 4px;
+.subject-card__next-review-text .hint {
+  font-size: 0.7rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.subject-card__body {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.subject-card__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.5);
+  color: rgba(226, 232, 240, 0.78);
+  padding: 0.45rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.details-btn:hover {
-  background: rgba(59, 130, 246, 0.3);
+.filter-pill:hover {
+  border-color: rgba(125, 211, 252, 0.4);
+  color: #e0f2fe;
 }
 
-.item-actions {
-  display: flex;
+.filter-pill--active {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: #e0f2fe;
+  box-shadow: 0 8px 18px -10px rgba(56, 189, 248, 0.4);
+}
+
+.filter-pill__counter {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.85);
+  padding: 0 0.45rem;
+  font-size: 0.7rem;
 }
 
-.study-controls {
+.subject-card__content {
   display: flex;
-  gap: 12px;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.accuracy-inputs, .review-inputs {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.accuracy-input, .review-input {
-  width: 60px;
-  padding: 4px 8px;
-  background: rgba(30, 41, 59, 0.8);
-  border: 1px solid rgba(71, 85, 105, 0.5);
-  border-radius: 4px;
-  color: #e2e8f0;
-  font-size: 0.8rem;
-}
-
-.save-btn {
-  padding: 4px 12px;
-  background: #3b82f6;
-  border: none;
-  border-radius: 4px;
-  color: white;
-  font-size: 0.8rem;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.save-btn:hover {
-  background: #2563eb;
-}
-
-.save-btn.review {
-  background: #ec4899;
-}
-
-.save-btn.review:hover {
-  background: #db2777;
-}
-
-.study-btn {
-  padding: 6px 16px;
-  background: #10b981;
-  border: none;
-  border-radius: 6px;
-  color: white;
+.subject-card__empty {
+  text-align: center;
+  padding: 1.25rem;
+  border-radius: 14px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.7);
   font-size: 0.85rem;
+}
+
+.syllabus-item-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.6);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.syllabus-item-card:hover {
+  border-color: rgba(56, 189, 248, 0.35);
+  transform: translateX(2px);
+}
+
+.syllabus-item-card--nested {
+  background: rgba(15, 23, 42, 0.45);
+  border-left: 3px solid rgba(59, 130, 246, 0.35);
+}
+
+.syllabus-item-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.syllabus-item-card__title-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.syllabus-item-card__marker {
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.12);
+}
+
+.syllabus-item-card__title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #f1f5f9;
+}
+
+.syllabus-item-card--nested .syllabus-item-card__title {
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.subject-card__icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(226, 232, 240, 0.9);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.study-btn:hover {
-  background: #059669;
+.subject-card__icon-btn:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  color: #e0f2fe;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.12);
+}
+
+.syllabus-item-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.item-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 9999px;
+  padding: 0.3rem 0.65rem;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.85);
+  font-weight: 500;
+}
+
+.item-chip__note {
+  font-size: 0.65rem;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 9999px;
+  padding: 0.1rem 0.35rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.item-chip--accuracy-high {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgba(16, 185, 129, 0.45);
+  color: #bbf7d0;
+}
+
+.item-chip--accuracy-medium {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.4);
+  color: #c7d2fe;
+}
+
+.item-chip--accuracy-low {
+  background: rgba(249, 115, 22, 0.18);
+  border-color: rgba(249, 115, 22, 0.4);
+  color: #fed7aa;
+}
+
+.item-chip--accuracy-critical {
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: #fecdd3;
+}
+
+.item-chip--weight {
+  background: rgba(244, 114, 182, 0.18);
+  border-color: rgba(244, 114, 182, 0.4);
+  color: #fbcfe8;
+}
+
+.item-chip--review-overdue {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecdd3;
+}
+
+.item-chip--review-today {
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(96, 165, 250, 0.4);
+  color: #dbeafe;
+}
+
+.item-chip--review-soon {
+  background: rgba(129, 140, 248, 0.18);
+  border-color: rgba(129, 140, 248, 0.4);
+  color: #e0e7ff;
+}
+
+.item-chip--review-upcoming {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.4);
+  color: #bae6fd;
+}
+
+.item-chip--status {
+  background: rgba(15, 118, 110, 0.18);
+  border-color: rgba(45, 212, 191, 0.35);
+  color: #99f6e4;
+}
+
+.syllabus-item-card__editor {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(2, 6, 23, 0.65);
+}
+
+.editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 140px;
+}
+
+.editor-field label {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.editor-input {
+  width: 100%;
+  padding: 0.45rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  font-size: 0.85rem;
+}
+
+.editor-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.editor-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.editor-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: 10px;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.editor-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.editor-btn--primary {
+  background: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);
+  color: #f8fafc;
+}
+
+.editor-btn--primary:hover:not(:disabled) {
+  box-shadow: 0 12px 24px -14px rgba(99, 102, 241, 0.8);
+}
+
+.editor-btn--success {
+  background: linear-gradient(135deg, #10b981 0%, #22d3ee 100%);
+  color: #f8fafc;
+}
+
+.editor-btn--success:hover:not(:disabled) {
+  box-shadow: 0 12px 24px -14px rgba(34, 211, 238, 0.7);
+}
+
+.editor-btn--ghost {
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.editor-btn--ghost:hover:not(:disabled) {
+  color: #e0f2fe;
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+@media (max-width: 640px) {
+  .subject-card {
+    padding: 1.25rem;
+  }
+
+  .subject-card__insights {
+    flex-direction: column;
+  }
+
+  .subject-card__progress-meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .subject-card__next-review,
+  .subject-card__progress {
+    min-width: unset;
+  }
 }
 
 /* Melhorias visuais */
@@ -652,12 +1069,6 @@
   max-width: 250px;
   background: rgba(51, 65, 85, 0.8);
   border: 1px solid rgba(148, 163, 184, 0.3);
-}
-
-.card {
-  background: rgba(15, 23, 42, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
 .subject-overview-header {
@@ -845,6 +1256,7 @@
   background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #334155 100%);
 }
 
+
 .loading-container {
   display: flex;
   justify-content: center;
@@ -855,12 +1267,13 @@
 }
 
 .loading-spinner {
-  width: 50px;
-  height: 50px;
-  border: 3px solid rgba(255, 255, 255, 0.3);
-  border-top: 3px solid #3b82f6;
+  width: 56px;
+  height: 56px;
+  border: 4px solid rgba(148, 163, 184, 0.25);
+  border-top-color: rgba(56, 189, 248, 0.85);
   border-radius: 50%;
-  animation: spin 1s linear infinite;
+  animation: spin 0.9s linear infinite;
+  box-shadow: 0 0 25px rgba(56, 189, 248, 0.25);
 }
 
 @keyframes spin {
@@ -1938,53 +2351,63 @@
 
 /* Ciclo de Estudos Visual */
 .study-cycle-indicator {
-  margin-top: 20px;
-  padding: 15px;
-  background: rgba(59, 130, 246, 0.1);
-  border-radius: 8px;
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  margin-top: 16px;
+  padding: 18px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(139, 92, 246, 0.06));
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(12px);
 }
 
 .study-cycle-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: 10px;
+  margin-bottom: 16px;
   font-weight: 600;
-  color: #3B82F6;
+  color: #e2e8f0;
 }
 
 .study-cycle-icon {
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .study-cycle-title {
-  font-size: 14px;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .study-cycle-subjects {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
 }
 
 .study-cycle-item {
   display: flex;
   flex-direction: column;
-  padding: 8px 12px;
-  border-radius: 6px;
-  min-width: 120px;
-  font-size: 12px;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+  min-height: 72px;
 }
 
 .cycle-subject-name {
   font-weight: 600;
-  margin-bottom: 2px;
+  font-size: 0.9rem;
+  color: #f8fafc;
 }
 
 .cycle-subject-weight {
-  color: #6B7280;
-  font-size: 11px;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 /* Modal de Sessão - Correção de scroll */
@@ -2412,4 +2835,292 @@
   .profile-actions {
     justify-content: center;
   }
+}
+
+/* Experience Navigator */
+.experience-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px;
+}
+
+.experience-showcase__header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+@media (min-width: 768px) {
+  .experience-showcase__header {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.experience-showcase__eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(125, 211, 252, 0.8);
+}
+
+.experience-showcase__title {
+  margin-top: 8px;
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.experience-showcase__subtitle {
+  margin-top: 12px;
+  max-width: 620px;
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.experience-showcase__profile {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(30, 64, 175, 0.12);
+  color: #e0f2fe;
+  min-width: 220px;
+}
+
+.experience-showcase__profile strong {
+  font-size: 1rem;
+  color: #f8fafc;
+}
+
+.experience-showcase__profile-date {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.experience-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.2);
+  border: 1px solid rgba(14, 165, 233, 0.4);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #bae6fd;
+}
+
+.experience-tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.experience-tab {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.experience-tab:hover {
+  transform: translateY(-2px);
+  border-color: rgba(14, 165, 233, 0.35);
+}
+
+.experience-tab--active {
+  background: rgba(14, 165, 233, 0.18);
+  border-color: rgba(14, 165, 233, 0.55);
+  box-shadow: 0 18px 45px -30px rgba(14, 165, 233, 0.75);
+}
+
+.experience-tab__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(14, 165, 233, 0.16);
+  color: #bae6fd;
+}
+
+.experience-tab__content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.experience-tab__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.experience-tab__badge {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.experience-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(2, 6, 23, 0.55);
+}
+
+@media (min-width: 1024px) {
+  .experience-panel {
+    padding: 28px;
+  }
+}
+
+.experience-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.experience-panel__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #bfdbfe;
+}
+
+.experience-panel__title {
+  margin-top: 10px;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.experience-panel__description {
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.85);
+  line-height: 1.7;
+}
+
+.experience-metrics {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .experience-metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.experience-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.experience-metric__value {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.experience-metric__label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.experience-metric__helper {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.experience-callouts {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding-left: 18px;
+  color: rgba(226, 232, 240, 0.95);
+  font-size: 0.92rem;
+}
+
+.experience-callouts li::marker {
+  color: rgba(125, 211, 252, 0.8);
+}
+
+.experience-actions {
+  display: grid;
+  gap: 12px;
+}
+
+@media (min-width: 640px) {
+  .experience-actions {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+.experience-action {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.experience-action__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(14, 165, 233, 0.18);
+  color: #bae6fd;
+}
+
+.experience-action__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.experience-action__description {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
 }


### PR DESCRIPTION
## Summary
- redesign the Visão geral das matérias cards with progress insights, upcoming review highlights, and filter chips for item states
- enrich each item row with accuracy, peso, revisão, and status badges plus in-place editing controls consistent with the new visual language
- replace legacy CSS with glassmorphism-inspired card, chip, and editor styles to align with the updated dashboard aesthetic
- add an ExperienceNavigator hub that apresenta Ciclo de Estudos, Revisões, Registro, Indicadores, Mapa, Edital, Configurações, Modo Offline e plataformas com métricas dinâmicas alinhadas ao app Estudei
- extend global styles with experience navigator layout, tab and metric cards following the refreshed glassmorphism approach

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d56875caec832db51b6d3049ea03d3