### PR TITLE
Add global editais, edital comparison UI and global progress synchronization

### DIFF
--- a/src/components/modals/EditalComparisonModal.jsx
+++ b/src/components/modals/EditalComparisonModal.jsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { getAvailableEditais } from '../../utils/editalManager';
+import { mergeEditaisContent } from '../../utils/editalComparison';
+
+const Chip = ({ label, variant = 'default' }) => {
+  const base = 'px-2 py-0.5 rounded-full text-xs font-medium';
+  const variants = {
+    default: 'bg-slate-700 text-slate-200',
+    unique: 'bg-amber-500/20 text-amber-300 border border-amber-500/30',
+    common: 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30'
+  };
+
+  return <span className={`${base} ${variants[variant] || variants.default}`}>{label}</span>;
+};
+
+export const EditalComparisonModal = ({ isOpen, onClose }) => {
+  const [selectedIds, setSelectedIds] = useState([]);
+  const availableEditais = useMemo(() => getAvailableEditais(), []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedIds([]);
+    }
+  }, [isOpen]);
+
+  const selectedEditais = useMemo(
+    () => availableEditais.filter((edital) => selectedIds.includes(edital.id)),
+    [availableEditais, selectedIds]
+  );
+
+  const mergedContent = useMemo(
+    () => mergeEditaisContent(selectedEditais),
+    [selectedEditais]
+  );
+
+  const toggleSelection = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+    );
+  };
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal large" onClick={(e) => e.stopPropagation()}>
+        <h2 className="flex items-center justify-between">
+          Comparar Editais
+          <button className="close-btn" onClick={onClose}>
+            ×
+          </button>
+        </h2>
+
+        <div className="p-6 space-y-6 max-h-[70vh] overflow-y-auto custom-scrollbar">
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-slate-300 uppercase tracking-wide">
+              Selecione dois ou mais editais
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {availableEditais.map((edital) => (
+                <label
+                  key={edital.id}
+                  className="flex items-start gap-3 p-3 rounded-lg border border-slate-700 bg-slate-800/60 hover:border-sky-500/60 transition-colors cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(edital.id)}
+                    onChange={() => toggleSelection(edital.id)}
+                    className="mt-1"
+                  />
+                  <div>
+                    <p className="text-sm font-semibold text-slate-200">{edital.nome}</p>
+                    <p className="text-xs text-slate-400">{edital.concurso || 'Edital global'}</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <Chip label={edital.source === 'global' ? 'Global' : 'Personalizado'} />
+                      {edital.arquivoPdf && (
+                        <Chip label="PDF disponível" />
+                      )}
+                    </div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          {selectedEditais.length > 0 && (
+            <section className="space-y-4">
+              <div className="flex flex-wrap gap-2 items-center">
+                <h3 className="text-sm font-semibold text-slate-300 uppercase tracking-wide">
+                  Resultado da sobreposição
+                </h3>
+                <Chip label={`Selecionados: ${selectedEditais.length}`} />
+                <Chip label="Único" variant="unique" />
+                <Chip label="Comum" variant="common" />
+              </div>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <div className="bg-slate-900/60 border border-slate-700 rounded-xl p-4">
+                  <h4 className="text-sm font-semibold text-slate-200 mb-3">Matérias</h4>
+                  <div className="space-y-2">
+                    {mergedContent.materias.length === 0 && (
+                      <p className="text-xs text-slate-500 italic">Nenhuma matéria encontrada.</p>
+                    )}
+                    {mergedContent.materias.map((materia) => (
+                      <div
+                        key={materia.key}
+                        className="p-2 rounded-lg border border-slate-700 bg-slate-800/60"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="text-sm text-slate-200">{materia.label}</p>
+                          <Chip
+                            label={materia.isUnique ? 'Único' : materia.isCommon ? 'Comum' : 'Parcial'}
+                            variant={materia.isUnique ? 'unique' : materia.isCommon ? 'common' : 'default'}
+                          />
+                        </div>
+                        {materia.labels?.length > 1 && (
+                          <p className="text-xs text-slate-400 mt-2">
+                            Variações: {materia.labels.join(' • ')}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="bg-slate-900/60 border border-slate-700 rounded-xl p-4">
+                  <h4 className="text-sm font-semibold text-slate-200 mb-3">Tópicos</h4>
+                  <div className="space-y-2">
+                    {mergedContent.topicos.length === 0 && (
+                      <p className="text-xs text-slate-500 italic">Nenhum tópico encontrado.</p>
+                    )}
+                    {mergedContent.topicos.map((topico) => (
+                      <div
+                        key={topico.key}
+                        className="p-2 rounded-lg border border-slate-700 bg-slate-800/60"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="text-sm text-slate-200">{topico.label}</p>
+                          <Chip
+                            label={topico.isUnique ? 'Único' : topico.isCommon ? 'Comum' : 'Parcial'}
+                            variant={topico.isUnique ? 'unique' : topico.isCommon ? 'common' : 'default'}
+                          />
+                        </div>
+                        {topico.labels?.length > 1 && (
+                          <p className="text-xs text-slate-400 mt-2">
+                            Variações: {topico.labels.join(' • ')}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/components/modals/ProfileModal.jsx
+++ b/src/components/modals/ProfileModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { sanitizeMultilineText, sanitizeText } from '../../utils/helpers';
+import { getAvailableEditais } from '../../utils/editalManager';
 
 export const ProfileModal = ({
     isOpen,
@@ -13,23 +14,29 @@ export const ProfileModal = ({
         name: '',
         description: '',
         examDate: '',
-        institution: ''
+        institution: '',
+        editalId: ''
     });
+    const [availableEditais, setAvailableEditais] = useState([]);
 
     useEffect(() => {
+        setAvailableEditais(getAvailableEditais());
+
         if (editingProfile) {
             setFormData({
                 name: editingProfile.name || '',
                 description: editingProfile.description || '',
                 examDate: editingProfile.examDate || '',
-                institution: editingProfile.institution || ''
+                institution: editingProfile.institution || '',
+                editalId: editingProfile.editalId || ''
             });
         } else {
             setFormData({
                 name: '',
                 description: '',
                 examDate: '',
-                institution: ''
+                institution: '',
+                editalId: ''
             });
         }
     }, [editingProfile]);
@@ -43,11 +50,15 @@ export const ProfileModal = ({
             return;
         }
 
+        const selectedEdital = availableEditais.find((edital) => edital.id === formData.editalId);
+
         onSubmit({
             name,
             description: sanitizeMultilineText(formData.description).slice(0, 500),
             examDate: sanitizeText(formData.examDate).slice(0, 20),
-            institution: sanitizeText(formData.institution).slice(0, 120)
+            institution: sanitizeText(formData.institution).slice(0, 120),
+            editalId: formData.editalId || '',
+            editalNome: selectedEdital?.nome || ''
         });
     };
 
@@ -119,6 +130,25 @@ export const ProfileModal = ({
                                 onFocus={(e) => e.stopPropagation()}
                                 placeholder="Ex: CESPE, FCC, VUNESP..."
                             />
+                        </div>
+
+                        <div className="form-group">
+                            <label className="form-label">Edital Global (opcional)</label>
+                            <select
+                                className="form-input"
+                                value={formData.editalId}
+                                onChange={(e) => setFormData(prev => ({ ...prev, editalId: e.target.value }))}
+                            >
+                                <option value="">Não selecionar edital</option>
+                                {availableEditais.map((edital) => (
+                                    <option key={edital.id} value={edital.id}>
+                                        {edital.nome}
+                                    </option>
+                                ))}
+                            </select>
+                            <p className="text-xs text-gray-500 mt-1">
+                                Selecione um edital global para importar matérias e comparar conteúdos.
+                            </p>
                         </div>
 
                         <div className="flex justify-end gap-3 pt-4">

--- a/src/components/modals/SyllabusModal.jsx
+++ b/src/components/modals/SyllabusModal.jsx
@@ -4,6 +4,7 @@ import { PlusCircle } from 'lucide-react';
 import { SyllabusProcessor } from '../SyllabusProcessor';
 import { sanitizeText } from '../../utils/helpers';
 import { saveToLocalStorage } from '../../utils/localStorage';
+import { isNameStudiedInProgress, loadGlobalProgress } from '../../utils/progressRegistry';
 
 export const SyllabusModal = ({
     isOpen,
@@ -22,11 +23,12 @@ export const SyllabusModal = ({
             return;
         }
 
+        const progressMap = loadGlobalProgress();
         const newItem = {
             id: Date.now().toString(),
             subjectId: currentSubjectForSyllabus.id,
             name,
-            isStudied: false,
+            isStudied: isNameStudiedInProgress(name, progressMap),
             createdAt: new Date().toISOString()
         };
 
@@ -44,11 +46,12 @@ export const SyllabusModal = ({
 
         if (cleaned.length === 0) return;
 
+        const progressMap = loadGlobalProgress();
         const newItems = cleaned.map((itemName, index) => ({
             id: (Date.now() + index).toString(),
             subjectId: currentSubjectForSyllabus.id,
             name: itemName,
-            isStudied: false,
+            isStudied: isNameStudiedInProgress(itemName, progressMap),
             createdAt: new Date().toISOString()
         }));
 
@@ -68,11 +71,12 @@ export const SyllabusModal = ({
         const anchorIndex = syllabusItems.findIndex(item => item.id === anchorItem.id);
         if (anchorIndex === -1) return;
 
+        const progressMap = loadGlobalProgress();
         const newItem = {
             id: `${Date.now()}`,
             subjectId: currentSubjectForSyllabus.id,
             name,
-            isStudied: false,
+            isStudied: isNameStudiedInProgress(name, progressMap),
             createdAt: new Date().toISOString()
         };
 

--- a/src/data/globalEditais.js
+++ b/src/data/globalEditais.js
@@ -1,0 +1,172 @@
+export const globalEditais = [
+  {
+    id: 'global-edital-enam-1',
+    nome: 'EDITAL ENAM 1',
+    concurso: 'ENAM 1',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL ENAM 1.pdf'
+  },
+  {
+    id: 'global-edital-enam-2024-2',
+    nome: 'EDITAL ENAM 2024.2',
+    concurso: 'ENAM 2024.2',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL ENAM 2024.2.pdf'
+  },
+  {
+    id: 'global-edital-enam-2025-1',
+    nome: 'EDITAL ENAM 2025.1',
+    concurso: 'ENAM 2025.1',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL ENAM 2025.1.pdf'
+  },
+  {
+    id: 'global-edital-mpf-2022',
+    nome: 'EDITAL MPF 2022',
+    concurso: 'MPF 2022',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL MPF 2022.pdf'
+  },
+  {
+    id: 'global-edital-mpf-2025',
+    nome: 'EDITAL MPF 2025',
+    concurso: 'MPF 2025',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL MPF 2025.pdf'
+  },
+  {
+    id: 'global-edital-mpgo-2023',
+    nome: 'EDITAL MPGO 2023',
+    concurso: 'MPGO 2023',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL MPGO 2023.pdf'
+  },
+  {
+    id: 'global-edital-mpmg-2024',
+    nome: 'EDITAL MPMG 2024',
+    concurso: 'MPMG 2024',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL MPMG 2024.pdf'
+  },
+  {
+    id: 'global-edital-mpmg',
+    nome: 'EDITAL MPMG',
+    concurso: 'MPMG',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL MPMG.pdf'
+  },
+  {
+    id: 'global-edital-mprs-2025',
+    nome: 'EDITAL MPRS 2025',
+    concurso: 'MPRS 2025',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL MPRS 2025.pdf'
+  },
+  {
+    id: 'global-edital-tjdft-2022-juiz',
+    nome: 'EDITAL TJDFT 2022 JUIZ',
+    concurso: 'TJDFT 2022 JUIZ',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL TJDFT 2022 JUIZ.pdf'
+  },
+  {
+    id: 'global-edital-tjmg-2021',
+    nome: 'EDITAL TJMG 2021',
+    concurso: 'TJMG 2021',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL TJMG 2021.pdf'
+  },
+  {
+    id: 'global-edital-tjsp-2024',
+    nome: 'EDITAL TJSP 2024',
+    concurso: 'TJSP 2024',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL TJSP 2024.pdf'
+  },
+  {
+    id: 'global-edital-trf2-2025',
+    nome: 'EDITAL TRF2 2025',
+    concurso: 'TRF2 2025',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/EDITAL TRF2 2025 .pdf'
+  },
+  {
+    id: 'global-edital-trf5-2025',
+    nome: 'TRF5 EDITAL 2025',
+    concurso: 'TRF5 2025',
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivoPdf: 'editais/TRF5 EDITAL 2025.pdf'
+  }
+];
+
+export default globalEditais;

--- a/src/hooks/useStudyData.js
+++ b/src/hooks/useStudyData.js
@@ -1,5 +1,12 @@
 import { useState, useEffect } from 'react';
 import { loadFromLocalStorage, saveToLocalStorage } from '../utils/localStorage';
+import { ensureGlobalEditais } from '../utils/editalManager';
+import {
+    isNameStudiedInProgress,
+    loadGlobalProgress,
+    saveGlobalProgress,
+    updateProgressForName
+} from '../utils/progressRegistry';
 
 /**
  * Custom hook to manage all study-related data (profiles, subjects, sessions, etc.)
@@ -19,16 +26,30 @@ export const useStudyData = (showToast) => {
         const initializeApp = async () => {
             try {
                 setIsLoading(true);
+                ensureGlobalEditais();
                 const savedProfiles = loadFromLocalStorage("studyProfiles") || [];
                 const savedActiveProfileId = loadFromLocalStorage("activeProfileId");
                 const savedSubjects = loadFromLocalStorage("subjects") || [];
                 const savedSessions = loadFromLocalStorage("sessions") || [];
                 const savedSyllabusItems = loadFromLocalStorage("syllabusItems") || [];
+                const globalProgress = loadGlobalProgress();
+
+                const normalizedItems = (Array.isArray(savedSyllabusItems) ? savedSyllabusItems : []).map((item) => {
+                    if (!item?.name) return item;
+                    if (item.isStudied) return item;
+                    if (isNameStudiedInProgress(item.name, globalProgress)) {
+                        return { ...item, isStudied: true };
+                    }
+                    return item;
+                });
 
                 setStudyProfiles(savedProfiles);
                 setSubjects(savedSubjects);
                 setStudySessions(savedSessions);
-                setSyllabusItems(savedSyllabusItems);
+                setSyllabusItems(normalizedItems);
+                if (normalizedItems.length > 0) {
+                    saveToLocalStorage("syllabusItems", normalizedItems);
+                }
 
                 if (savedProfiles.length > 0) {
                     setActiveProfileId(savedActiveProfileId || savedProfiles[0].id);
@@ -134,7 +155,7 @@ export const useStudyData = (showToast) => {
         // Handle Syllabus Item Updates (Mark Studied OR Next Review Date)
         if (sessionData.syllabusItemId) {
             setSyllabusItems((prev) => {
-                const updated = prev.map((i) => {
+                let updated = prev.map((i) => {
                     if (i.id !== sessionData.syllabusItemId) return i;
 
                     const updates = {};
@@ -143,6 +164,25 @@ export const useStudyData = (showToast) => {
 
                     return Object.keys(updates).length > 0 ? { ...i, ...updates } : i;
                 });
+
+                let progressMap = loadGlobalProgress();
+                if (markTopicStudied) {
+                    const item = updated.find((i) => i.id === sessionData.syllabusItemId);
+                    if (item?.name) {
+                        progressMap = updateProgressForName(item.name, progressMap, true);
+                        saveGlobalProgress(progressMap);
+                    }
+                }
+
+                if (markTopicStudied) {
+                    updated = updated.map((item) => {
+                        if (!item?.name) return item;
+                        return {
+                            ...item,
+                            isStudied: isNameStudiedInProgress(item.name, progressMap)
+                        };
+                    });
+                }
 
                 // Only save if changed (optimization, but map always returns new array so simple save)
                 saveToLocalStorage("syllabusItems", updated);
@@ -159,9 +199,26 @@ export const useStudyData = (showToast) => {
 
     const updateSyllabusItem = (itemId, updates) => {
         setSyllabusItems((prev) => {
-            const updated = prev.map((i) =>
+            let updated = prev.map((i) =>
                 i.id === itemId ? { ...i, ...updates } : i,
             );
+
+            if (Object.prototype.hasOwnProperty.call(updates || {}, 'isStudied')) {
+                const item = updated.find((i) => i.id === itemId);
+                if (item?.name) {
+                    const progressMap = loadGlobalProgress();
+                    const nextMap = updateProgressForName(item.name, progressMap, updates.isStudied);
+                    saveGlobalProgress(nextMap);
+                    updated = updated.map((currentItem) => {
+                        if (!currentItem?.name) return currentItem;
+                        return {
+                            ...currentItem,
+                            isStudied: isNameStudiedInProgress(currentItem.name, nextMap)
+                        };
+                    });
+                }
+            }
+
             saveToLocalStorage("syllabusItems", updated);
             return updated;
         });

--- a/src/pages/Subjects.jsx
+++ b/src/pages/Subjects.jsx
@@ -9,13 +9,14 @@ import { SessionModal } from '../components/SessionModal';
 import { SyllabusModal } from '../components/modals/SyllabusModal';
 import { SessionHistoryModal } from '../components/modals/SessionHistoryModal';
 import { ConfirmationModal } from '../components/ui/ConfirmationModal';
-import { saveToLocalStorage } from '../utils/localStorage';
+import { EditalComparisonModal } from '../components/modals/EditalComparisonModal';
 
 export const Subjects = () => {
   const {
     activeSubjects,
     activeSyllabusItems,
     setSyllabusItems,
+    updateSyllabusItem,
     activeSessions,
     addOrUpdateSession,
     deleteSession,
@@ -79,6 +80,7 @@ export const Subjects = () => {
   const [isItemDetailsModalOpen, setIsItemDetailsModalOpen] = useState(false);
   const [isSyllabusModalOpen, setIsSyllabusModalOpen] = useState(false);
   const [isSessionHistoryModalOpen, setIsSessionHistoryModalOpen] = useState(false);
+  const [isEditalComparisonOpen, setIsEditalComparisonOpen] = useState(false);
 
   // Context for modals
   const [currentSubjectForSession, setCurrentSubjectForSession] = useState(null);
@@ -95,15 +97,11 @@ export const Subjects = () => {
   });
 
   const handleToggleStudied = (itemId) => {
-    setSyllabusItems((prev) => {
-      const item = prev.find((i) => i.id === itemId);
-      if (!item) return prev;
-      const newStatus = !item.isStudied;
-      showToast(newStatus ? "Marcado como estudado!" : "Desmarcado.", "success");
-      const updated = prev.map((i) => i.id === itemId ? { ...i, isStudied: newStatus } : i);
-      saveToLocalStorage("syllabusItems", updated);
-      return updated;
-    });
+    const item = activeSyllabusItems.find((i) => i.id === itemId);
+    if (!item) return;
+    const newStatus = !item.isStudied;
+    updateSyllabusItem(itemId, { isStudied: newStatus });
+    showToast(newStatus ? "Marcado como estudado!" : "Desmarcado.", "success");
   };
 
   const handleSubjectSubmit = (data) => {
@@ -140,11 +138,17 @@ export const Subjects = () => {
           <p className="text-slate-400">Gerencie seus estudos e acompanhe o edital.</p>
         </div>
         <div className="flex gap-3">
-           <button
+          <button
             className="btn btn-secondary flex items-center gap-2"
             onClick={() => setIsSubjectModalOpen(true)}
           >
             <PlusCircle size={18} /> Nova Matéria
+          </button>
+          <button
+            className="btn btn-secondary flex items-center gap-2"
+            onClick={() => setIsEditalComparisonOpen(true)}
+          >
+            <PlusCircle size={18} /> Comparar Editais
           </button>
           <button
             className="btn btn-primary flex items-center gap-2"
@@ -222,6 +226,10 @@ export const Subjects = () => {
         syllabusItems={activeSyllabusItems}
         setSyllabusItems={setSyllabusItems}
         showToast={showToast}
+      />
+      <EditalComparisonModal
+        isOpen={isEditalComparisonOpen}
+        onClose={() => setIsEditalComparisonOpen(false)}
       />
       <SessionHistoryModal
         isOpen={isSessionHistoryModalOpen}

--- a/src/services/DataSyncService.js
+++ b/src/services/DataSyncService.js
@@ -82,6 +82,8 @@ export const DataSyncService = {
             ),
             examDate: sanitizeText(p?.examDate || "").slice(0, 20),
             institution: sanitizeText(p?.institution || "").slice(0, 120),
+            editalId: sanitizeText(p?.editalId || "").slice(0, 120),
+            editalNome: sanitizeText(p?.editalNome || "").slice(0, 120),
             createdAt: p?.createdAt || new Date().toISOString(),
           }))
           .filter((p) => p.id && p.name);

--- a/src/utils/editalComparison.js
+++ b/src/utils/editalComparison.js
@@ -1,0 +1,92 @@
+import {
+  normalizeEditalText,
+  resolveEditalTextKey,
+  splitEditalTextVariants
+} from './editalMatching';
+import { sanitizeText } from './helpers';
+
+const normalizeItemLabel = (text) => sanitizeText(String(text || '')).slice(0, 220);
+
+const extractItemNames = (items) => {
+  if (!Array.isArray(items)) return [];
+  return items
+    .flatMap((item) => {
+      if (typeof item === 'string') return [item];
+      if (item?.nome) return [item.nome];
+      if (item?.name) return [item.name];
+      return [];
+    })
+    .map((item) => normalizeItemLabel(item))
+    .filter(Boolean);
+};
+
+const addItemToGroups = (groups, rawText, sourceId, sourceLabel) => {
+  const existingKeys = new Set(groups.map((group) => group.key));
+  const key = resolveEditalTextKey(rawText, existingKeys);
+  if (!key) return;
+
+  let group = groups.find((item) => item.key === key);
+  if (!group) {
+    group = {
+      key,
+      label: normalizeItemLabel(rawText),
+      normalized: normalizeEditalText(rawText),
+      sources: new Set(),
+      labels: new Set()
+    };
+    groups.push(group);
+  }
+
+  group.sources.add(sourceId);
+  if (sourceLabel) group.labels.add(sourceLabel);
+  if (rawText) group.labels.add(normalizeItemLabel(rawText));
+};
+
+export const mergeEditaisContent = (editais) => {
+  const materiasGroups = [];
+  const topicosGroups = [];
+
+  (Array.isArray(editais) ? editais : []).forEach((edital) => {
+    const sourceId = edital?.id;
+    const sourceLabel = normalizeItemLabel(edital?.nome || edital?.concurso || '');
+
+    const materias = extractItemNames(edital?.materias);
+    materias.forEach((materia) => addItemToGroups(materiasGroups, materia, sourceId, sourceLabel));
+
+    const itens = extractItemNames(edital?.itensEdital);
+    itens
+      .flatMap((item) => splitEditalTextVariants(item))
+      .forEach((topico) => addItemToGroups(topicosGroups, topico, sourceId, sourceLabel));
+  });
+
+  const formatGroup = (group, totalSources) => {
+    const sources = Array.from(group.sources || []);
+    const labels = Array.from(group.labels || []);
+    const label = group.label || labels[0] || '';
+
+    return {
+      key: group.key,
+      label,
+      sources,
+      labels,
+      count: sources.length,
+      isUnique: sources.length === 1,
+      isCommon: sources.length === totalSources && totalSources > 1
+    };
+  };
+
+  const totalSources = new Set(
+    (Array.isArray(editais) ? editais : [])
+      .map((edital) => edital?.id)
+      .filter(Boolean)
+  ).size;
+
+  return {
+    materias: materiasGroups
+      .map((group) => formatGroup(group, totalSources))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    topicos: topicosGroups
+      .map((group) => formatGroup(group, totalSources))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  };
+};

--- a/src/utils/editalManager.js
+++ b/src/utils/editalManager.js
@@ -1,5 +1,27 @@
 // Utilitários para gerenciar editais administrativos
 import { loadFromLocalStorage, saveToLocalStorage } from './localStorage';
+import { globalEditais } from '../data/globalEditais';
+
+const GLOBAL_EDITAIS_KEY = 'global_editais';
+
+export const ensureGlobalEditais = () => {
+  const saved = loadFromLocalStorage(GLOBAL_EDITAIS_KEY, []);
+  if (Array.isArray(saved) && saved.length > 0) return saved;
+
+  saveToLocalStorage(GLOBAL_EDITAIS_KEY, globalEditais);
+  return globalEditais;
+};
+
+export const loadGlobalEditais = () => {
+  try {
+    const saved = loadFromLocalStorage(GLOBAL_EDITAIS_KEY, []);
+    if (Array.isArray(saved) && saved.length > 0) return saved;
+    return ensureGlobalEditais();
+  } catch (error) {
+    console.error('Erro ao carregar editais globais:', error);
+    return globalEditais;
+  }
+};
 
 export const loadAdminEditais = () => {
   try {
@@ -14,14 +36,14 @@ export const loadAdminEditais = () => {
 export const saveAdminEditais = (editais) => {
   try {
     saveToLocalStorage('admin_editais', editais);
-    
+
     // Salvar também como arquivo JSON para simulação de database
     const dataStr = JSON.stringify(editais, null, 2);
     const blob = new Blob([dataStr], { type: 'application/json' });
-    
+
     // Em uma aplicação real, isso seria uma chamada para API
     console.log('Editais salvos:', editais.length, 'itens');
-    
+
     return true;
   } catch (error) {
     console.error('Erro ao salvar editais:', error);
@@ -30,8 +52,10 @@ export const saveAdminEditais = (editais) => {
 };
 
 export const getAvailableEditais = () => {
-  const editais = loadAdminEditais();
-  return editais.map(edital => ({
+  const adminEditais = loadAdminEditais();
+  const global = loadGlobalEditais();
+
+  return [...global, ...adminEditais].map((edital) => ({
     id: edital.id,
     nome: edital.nome,
     concurso: edital.concurso,
@@ -39,18 +63,20 @@ export const getAvailableEditais = () => {
     banca: edital.banca,
     dataProva: edital.dataProva,
     materias: edital.materias || [],
-    itensEdital: edital.itensEdital || []
+    itensEdital: edital.itensEdital || [],
+    arquivoPdf: edital.arquivoPdf || '',
+    source: global.some((item) => item.id === edital.id) ? 'global' : 'admin'
   }));
 };
 
 export const getEditalById = (id) => {
-  const editais = loadAdminEditais();
-  return editais.find(edital => edital.id === id);
+  const editais = [...loadGlobalEditais(), ...loadAdminEditais()];
+  return editais.find((edital) => edital.id === id);
 };
 
 export const createProfileFromEdital = (edital, profileName) => {
   if (!edital) return null;
-  
+
   return {
     id: Date.now(),
     name: profileName,

--- a/src/utils/editalMatching.js
+++ b/src/utils/editalMatching.js
@@ -1,0 +1,89 @@
+import { sanitizeText } from './helpers';
+
+const STOP_WORDS = new Set([
+  'de',
+  'da',
+  'do',
+  'das',
+  'dos',
+  'e',
+  'em',
+  'no',
+  'na',
+  'nos',
+  'nas',
+  'para',
+  'por',
+  'ao',
+  'aos'
+]);
+
+export const normalizeEditalText = (text) => {
+  if (!text) return '';
+  const base = sanitizeText(String(text))
+    .replace(/^\d+(?:\.\d+)*\.?\s*/g, '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+  const cleaned = base
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) return '';
+
+  const tokens = cleaned.split(' ').filter((token) => token && !STOP_WORDS.has(token));
+  return tokens.join(' ').trim();
+};
+
+export const splitEditalTextVariants = (text) => {
+  if (!text) return [];
+  const cleaned = sanitizeText(String(text));
+  if (!cleaned) return [];
+
+  const segments = cleaned
+    .split(/\s*;\s*/g)
+    .map((segment) => sanitizeText(segment))
+    .filter(Boolean);
+
+  return segments.length > 0 ? segments : [cleaned];
+};
+
+export const tokenizeNormalizedText = (normalizedText) => {
+  if (!normalizedText) return [];
+  return normalizedText.split(' ').filter(Boolean);
+};
+
+export const isSimilarNormalizedText = (candidate, target, threshold = 0.75) => {
+  if (!candidate || !target) return false;
+  if (candidate === target) return true;
+  if (candidate.includes(target) || target.includes(candidate)) return true;
+
+  const candidateTokens = new Set(tokenizeNormalizedText(candidate));
+  const targetTokens = new Set(tokenizeNormalizedText(target));
+  if (candidateTokens.size === 0 || targetTokens.size === 0) return false;
+
+  let intersection = 0;
+  candidateTokens.forEach((token) => {
+    if (targetTokens.has(token)) intersection += 1;
+  });
+
+  const union = new Set([...candidateTokens, ...targetTokens]).size;
+  const similarity = union === 0 ? 0 : intersection / union;
+  return similarity >= threshold;
+};
+
+export const resolveEditalTextKey = (rawText, existingKeys) => {
+  const normalized = normalizeEditalText(rawText);
+  if (!normalized) return '';
+  if (existingKeys.has(normalized)) return normalized;
+
+  for (const key of existingKeys) {
+    if (isSimilarNormalizedText(normalized, key)) {
+      return key;
+    }
+  }
+
+  return normalized;
+};

--- a/src/utils/progressRegistry.js
+++ b/src/utils/progressRegistry.js
@@ -1,0 +1,44 @@
+import { loadFromLocalStorage, saveToLocalStorage } from './localStorage';
+import { normalizeEditalText, splitEditalTextVariants } from './editalMatching';
+
+const GLOBAL_PROGRESS_KEY = 'global_syllabus_progress';
+
+export const loadGlobalProgress = () => {
+  const saved = loadFromLocalStorage(GLOBAL_PROGRESS_KEY, {});
+  return saved && typeof saved === 'object' && !Array.isArray(saved) ? saved : {};
+};
+
+export const saveGlobalProgress = (progressMap) => {
+  saveToLocalStorage(GLOBAL_PROGRESS_KEY, progressMap || {});
+};
+
+export const getProgressKeysForName = (name) => {
+  if (!name) return [];
+  const variants = splitEditalTextVariants(name);
+  const keys = variants
+    .map((variant) => normalizeEditalText(variant))
+    .filter(Boolean);
+
+  return Array.from(new Set(keys));
+};
+
+export const isNameStudiedInProgress = (name, progressMap) => {
+  const keys = getProgressKeysForName(name);
+  return keys.some((key) => progressMap?.[key]?.isStudied);
+};
+
+export const updateProgressForName = (name, progressMap, isStudied) => {
+  const keys = getProgressKeysForName(name);
+  if (keys.length === 0) return progressMap;
+
+  const next = { ...progressMap };
+  const updatedAt = new Date().toISOString();
+  keys.forEach((key) => {
+    next[key] = {
+      isStudied: Boolean(isStudied),
+      updatedAt
+    };
+  });
+
+  return next;
+};


### PR DESCRIPTION
### Motivation

- Provide a set of pre-seeded (global) editais from the repository `editais/` so users can pick an existing edital instead of creating one manually.  
- Allow opening/overlaying two or more editais and present a merged view that highlights unique and common materias/tópicos.  
- Keep syllabus progress consistent across editais by recognizing slightly different labels (normalization/fuzzy matching).  
- Expose global editais in profile creation so a profile can be tied to an existing edital.

### Description

- Seeded global editais and manager: added `src/data/globalEditais.js` and extended `src/utils/editalManager.js` to `ensure`/load global editais and expose `getAvailableEditais`/`getEditalById`.  
- Edital comparison and matching: added `src/components/modals/EditalComparisonModal.jsx` to select and compare editais, plus comparison utilities `src/utils/editalComparison.js` and normalization/matching helpers `src/utils/editalMatching.js`.  
- Global progress registry: added `src/utils/progressRegistry.js` to normalize labels into keys and persist a global syllabus progress map; integrated reads/writes into study data flows.  
- Syllabus/profile integration: updated `src/hooks/useStudyData.js` to seed global editais on init, to sync `isStudied` across matching labels, and to update the global progress when items are marked studied; updated `src/components/modals/SyllabusModal.jsx` to consult global progress when adding/importing items; updated `src/components/modals/ProfileModal.jsx` to allow selecting a global edital when creating/editing a profile; added `EditalComparisonModal` opening from `src/pages/Subjects.jsx`.  
- Data import/export: `src/services/DataSyncService.js` updated to preserve `editalId`/`editalNome` fields on profile import.  

### Testing

- Started the dev server with `npm run dev` (Vite reported ready) and the app served at the local URL (startup succeeded).  
- Ran an automated UI check that opened `/subjects` and clicked the `Comparar Editais` button, producing a screenshot artifact of the comparison modal (Playwright run completed and screenshot saved).  
- No unit tests were executed as part of this change (`npm run test` was not run).  
- All automated runs described above completed without fatal errors (modal screenshot available as verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f4781830832d882e551a2459a87f)