### PR TITLE
Add global edital selection, merging and comparison

### DIFF
--- a/src/components/modals/EditalComparisonModal.jsx
+++ b/src/components/modals/EditalComparisonModal.jsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { mergeEditais } from '../../utils/editalComparison';
+
+export const EditalComparisonModal = ({ isOpen, onClose, editais }) => {
+  const merged = useMemo(() => mergeEditais(editais), [editais]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="modal large" onClick={(e) => e.stopPropagation()}>
+        <h2>
+          Comparativo de Editais
+          <button className="close-btn" onClick={onClose}>
+            ×
+          </button>
+        </h2>
+        <div className="modal-content-scroll">
+          <div className="space-y-4">
+            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+              <p className="text-sm text-slate-300">
+                {merged.totalEditais} edital(is) selecionado(s). Itens marcados como{' '}
+                <span className="text-amber-300 font-semibold">Exclusivo</span> aparecem apenas em um edital.
+              </p>
+            </div>
+
+            {merged.subjects.length === 0 ? (
+              <p className="text-slate-400">Nenhum conteúdo para comparar.</p>
+            ) : (
+              <div className="space-y-4">
+                {merged.subjects.map((subject) => (
+                  <div key={subject.key} className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <h3 className="text-base font-semibold text-white">{subject.name}</h3>
+                      {merged.totalEditais > 1 && (
+                        <span
+                          className={`text-xs font-semibold px-2 py-1 rounded-full border ${
+                            subject.count === 1
+                              ? 'border-amber-400/40 bg-amber-500/10 text-amber-300'
+                              : 'border-emerald-400/30 bg-emerald-500/10 text-emerald-300'
+                          }`}
+                        >
+                          {subject.count === 1 ? 'Exclusivo' : `${subject.count}/${subject.totalEditais}`}
+                        </span>
+                      )}
+                    </div>
+
+                    {subject.topics.length > 0 ? (
+                      <ul className="mt-3 space-y-2">
+                        {subject.topics.map((topic) => (
+                          <li
+                            key={topic.key}
+                            className={`flex items-start justify-between gap-3 rounded-lg border px-3 py-2 text-sm ${
+                              merged.totalEditais > 1 && topic.count === 1
+                                ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
+                                : 'border-slate-800 bg-slate-900/40 text-slate-200'
+                            }`}
+                          >
+                            <span className="flex-1">{topic.name}</span>
+                            {merged.totalEditais > 1 && (
+                              <span
+                                className={`text-xs font-semibold ${
+                                  topic.count === 1 ? 'text-amber-300' : 'text-emerald-300'
+                                }`}
+                              >
+                                {topic.count === 1 ? 'Exclusivo' : `${topic.count}/${topic.totalEditais}`}
+                              </span>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-3 text-sm text-slate-400">Nenhum tópico informado neste edital.</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/components/modals/SyllabusModal.jsx
+++ b/src/components/modals/SyllabusModal.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { PlusCircle } from 'lucide-react';
 import { SyllabusProcessor } from '../SyllabusProcessor';
 import { sanitizeText } from '../../utils/helpers';
+import { normalizeStudyName } from '../../utils/editalComparison';
 import { saveToLocalStorage } from '../../utils/localStorage';
 
 export const SyllabusModal = ({
@@ -26,6 +27,7 @@ export const SyllabusModal = ({
             id: Date.now().toString(),
             subjectId: currentSubjectForSyllabus.id,
             name,
+            normalizedKey: normalizeStudyName(name),
             isStudied: false,
             createdAt: new Date().toISOString()
         };
@@ -48,6 +50,7 @@ export const SyllabusModal = ({
             id: (Date.now() + index).toString(),
             subjectId: currentSubjectForSyllabus.id,
             name: itemName,
+            normalizedKey: normalizeStudyName(itemName),
             isStudied: false,
             createdAt: new Date().toISOString()
         }));
@@ -72,6 +75,7 @@ export const SyllabusModal = ({
             id: `${Date.now()}`,
             subjectId: currentSubjectForSyllabus.id,
             name,
+            normalizedKey: normalizeStudyName(name),
             isStudied: false,
             createdAt: new Date().toISOString()
         };
@@ -90,7 +94,7 @@ export const SyllabusModal = ({
             return;
         }
         const updatedItems = syllabusItems.map(item =>
-            item.id === itemId ? { ...item, name: cleaned } : item
+            item.id === itemId ? { ...item, name: cleaned, normalizedKey: normalizeStudyName(cleaned) } : item
         );
         setSyllabusItems(updatedItems);
         saveToLocalStorage('syllabusItems', updatedItems);

--- a/src/data/globalEditais.js
+++ b/src/data/globalEditais.js
@@ -1,0 +1,199 @@
+const now = new Date().toISOString();
+
+const createPdfEdital = (filename) => {
+  const displayName = filename.replace(/\.pdf$/i, '').trim();
+  const concurso = displayName.replace(/^EDITAL\s*/i, '').trim();
+  const slug = displayName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return {
+    id: `global-${slug}`,
+    nome: displayName,
+    concurso: concurso || displayName,
+    orgao: '',
+    banca: '',
+    dataProva: '',
+    inscricoesAte: '',
+    materias: [],
+    itensEdital: [],
+    arquivo: filename,
+    isGlobal: true,
+    dataAtualização: now
+  };
+};
+
+const pdfEditais = [
+  'EDITAL ENAM 1.pdf',
+  'EDITAL ENAM 2024.2.pdf',
+  'EDITAL ENAM 2025.1.pdf',
+  'EDITAL MPF 2022.pdf',
+  'EDITAL MPF 2025.pdf',
+  'EDITAL MPGO 2023.pdf',
+  'EDITAL MPMG 2024.pdf',
+  'EDITAL MPMG.pdf',
+  'EDITAL MPRS 2025.pdf',
+  'EDITAL TJDFT 2022 JUIZ.pdf',
+  'EDITAL TJMG 2021.pdf',
+  'EDITAL TJSP 2024.pdf',
+  'EDITAL TRF2 2025 .pdf',
+  'TRF5 EDITAL 2025.pdf'
+].map(createPdfEdital);
+
+const exampleEditais = [
+  {
+    id: 'exemplo-trt15-2024',
+    nome: 'Edital nº 001/2024',
+    concurso: 'Analista Judiciário - TRT 15ª Região',
+    orgao: 'Tribunal Regional do Trabalho da 15ª Região',
+    banca: 'FCC',
+    dataProva: '2025-05-15',
+    inscricoesAte: '2025-03-15',
+    materias: [
+      {
+        id: 'exemplo-trt15-2024-materia-1',
+        nome: 'Direito Constitucional',
+        peso: 3
+      },
+      {
+        id: 'exemplo-trt15-2024-materia-2',
+        nome: 'Direito Administrativo',
+        peso: 3
+      },
+      {
+        id: 'exemplo-trt15-2024-materia-3',
+        nome: 'Direito do Trabalho',
+        peso: 4
+      },
+      {
+        id: 'exemplo-trt15-2024-materia-4',
+        nome: 'Direito Processual do Trabalho',
+        peso: 4
+      },
+      {
+        id: 'exemplo-trt15-2024-materia-5',
+        nome: 'Português',
+        peso: 2
+      }
+    ],
+    itensEdital: [
+      {
+        id: 'exemplo-trt15-2024-item-1',
+        nome: '1. Direitos e garantias fundamentais'
+      },
+      {
+        id: 'exemplo-trt15-2024-item-2',
+        nome: '2. Organização do Estado'
+      },
+      {
+        id: 'exemplo-trt15-2024-item-3',
+        nome: '3. Administração Pública'
+      },
+      {
+        id: 'exemplo-trt15-2024-item-4',
+        nome: '4. Servidores públicos'
+      },
+      {
+        id: 'exemplo-trt15-2024-item-5',
+        nome: '5. Contrato individual de trabalho'
+      },
+      {
+        id: 'exemplo-trt15-2024-item-6',
+        nome: '6. Organização sindical'
+      },
+      {
+        id: 'exemplo-trt15-2024-item-7',
+        nome: '7. Procedimento ordinário trabalhista'
+      },
+      {
+        id: 'exemplo-trt15-2024-item-8',
+        nome: '8. Recursos trabalhistas'
+      }
+    ],
+    isGlobal: true,
+    dataAtualização: '2024-12-17T21:00:00.000Z'
+  },
+  {
+    id: 'exemplo-trf3-2024',
+    nome: 'Edital nº 002/2024',
+    concurso: 'Técnico Judiciário - TRF 3ª Região',
+    orgao: 'Tribunal Regional Federal da 3ª Região',
+    banca: 'CESPE',
+    dataProva: '2025-04-20',
+    inscricoesAte: '2025-02-20',
+    materias: [
+      {
+        id: 'exemplo-trf3-2024-materia-1',
+        nome: 'Direito Constitucional',
+        peso: 2
+      },
+      {
+        id: 'exemplo-trf3-2024-materia-2',
+        nome: 'Direito Administrativo',
+        peso: 2
+      },
+      {
+        id: 'exemplo-trf3-2024-materia-3',
+        nome: 'Português',
+        peso: 3
+      },
+      {
+        id: 'exemplo-trf3-2024-materia-4',
+        nome: 'Informática',
+        peso: 2
+      },
+      {
+        id: 'exemplo-trf3-2024-materia-5',
+        nome: 'Raciocínio Lógico',
+        peso: 1
+      }
+    ],
+    itensEdital: [
+      {
+        id: 'exemplo-trf3-2024-item-1',
+        nome: '1. Princípios constitucionais'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-2',
+        nome: '2. Direitos sociais'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-3',
+        nome: '3. Organização administrativa'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-4',
+        nome: '4. Atos administrativos'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-5',
+        nome: '5. Licitações e contratos'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-6',
+        nome: '6. Interpretação de texto'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-7',
+        nome: '7. Gramática'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-8',
+        nome: '8. Sistema operacional Windows'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-9',
+        nome: '9. Microsoft Office'
+      },
+      {
+        id: 'exemplo-trf3-2024-item-10',
+        nome: '10. Proposições lógicas'
+      }
+    ],
+    isGlobal: true,
+    dataAtualização: '2024-12-17T21:10:00.000Z'
+  }
+];
+
+export const globalEditaisSeed = [...pdfEditais, ...exampleEditais];

--- a/src/hooks/useStudyData.js
+++ b/src/hooks/useStudyData.js
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 import { loadFromLocalStorage, saveToLocalStorage } from '../utils/localStorage';
+import { seedGlobalEditais } from '../utils/editalManager';
+import { normalizeStudyName } from '../utils/editalComparison';
 
 /**
  * Custom hook to manage all study-related data (profiles, subjects, sessions, etc.)
@@ -19,6 +21,7 @@ export const useStudyData = (showToast) => {
         const initializeApp = async () => {
             try {
                 setIsLoading(true);
+                seedGlobalEditais();
                 const savedProfiles = loadFromLocalStorage("studyProfiles") || [];
                 const savedActiveProfileId = loadFromLocalStorage("activeProfileId");
                 const savedSubjects = loadFromLocalStorage("subjects") || [];
@@ -84,13 +87,14 @@ export const useStudyData = (showToast) => {
     };
 
     const addOrUpdateSubject = (subjectData, editingId = null) => {
+        const normalizedKey = normalizeStudyName(subjectData?.name);
         const newSubjects = editingId
             ? subjects.map((s) =>
-                s.id === editingId ? { ...s, ...subjectData } : s,
+                s.id === editingId ? { ...s, ...subjectData, normalizedKey } : s,
             )
             : [
                 ...subjects,
-                { id: Date.now().toString(), profileId: activeProfileId, ...subjectData },
+                { id: Date.now().toString(), profileId: activeProfileId, ...subjectData, normalizedKey },
             ];
 
         setSubjects(newSubjects);
@@ -159,12 +163,21 @@ export const useStudyData = (showToast) => {
 
     const updateSyllabusItem = (itemId, updates) => {
         setSyllabusItems((prev) => {
+            const normalizedKey = updates?.name ? normalizeStudyName(updates.name) : undefined;
             const updated = prev.map((i) =>
-                i.id === itemId ? { ...i, ...updates } : i,
+                i.id === itemId ? { ...i, ...updates, ...(normalizedKey ? { normalizedKey } : {}) } : i,
             );
             saveToLocalStorage("syllabusItems", updated);
             return updated;
         });
+    };
+
+    const updateProfileEditais = (profileId, editalIds) => {
+        const updatedProfiles = studyProfiles.map((profile) =>
+            profile.id === profileId ? { ...profile, editalIds } : profile,
+        );
+        setStudyProfiles(updatedProfiles);
+        saveToLocalStorage("studyProfiles", updatedProfiles);
     };
 
     return {
@@ -189,6 +202,7 @@ export const useStudyData = (showToast) => {
         deleteSubject,
         addOrUpdateSession,
         deleteSession,
-        updateSyllabusItem
+        updateSyllabusItem,
+        updateProfileEditais
     };
 };

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,9 +1,13 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useStudyContext } from '../context/StudyContext';
 import { ProfileModal } from '../components/modals/ProfileModal';
-import { Trash2, Edit2, Download, Upload, AlertTriangle } from 'lucide-react';
+import { Trash2, Edit2, Download, Upload, AlertTriangle, Layers } from 'lucide-react';
 import { DataSyncService } from '../services/DataSyncService';
 import { ConfirmationModal } from '../components/ui/ConfirmationModal';
+import { seedGlobalEditais, getAvailableEditais } from '../utils/editalManager';
+import { mergeStudyContentWithExisting } from '../utils/editalComparison';
+import { saveToLocalStorage } from '../utils/localStorage';
+import { EditalComparisonModal } from '../components/modals/EditalComparisonModal';
 
 export const Settings = () => {
   const {
@@ -19,11 +23,15 @@ export const Settings = () => {
     subjects,
     studySessions,
     syllabusItems,
-    showToast
+    showToast,
+    updateProfileEditais
   } = useStudyContext();
 
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [editingProfile, setEditingProfile] = useState(null);
+  const [editais, setEditais] = useState([]);
+  const [selectedEditalIds, setSelectedEditalIds] = useState([]);
+  const [isComparisonOpen, setIsComparisonOpen] = useState(false);
 
   const [confirmationDialog, setConfirmationDialog] = useState({
     isOpen: false,
@@ -31,6 +39,16 @@ export const Settings = () => {
     message: "",
     onConfirm: () => { },
   });
+
+  useEffect(() => {
+    seedGlobalEditais();
+    setEditais(getAvailableEditais());
+  }, []);
+
+  useEffect(() => {
+    const activeProfile = studyProfiles.find((profile) => profile.id === activeProfileId);
+    setSelectedEditalIds(Array.isArray(activeProfile?.editalIds) ? activeProfile.editalIds : []);
+  }, [activeProfileId, studyProfiles]);
 
   const handleProfileSubmit = (data) => {
     addOrUpdateProfile(data, editingProfile?.id);
@@ -70,6 +88,69 @@ export const Settings = () => {
       setActiveProfileId,
       showToast
     });
+  };
+
+  const selectedEditais = useMemo(
+    () => editais.filter((edital) => selectedEditalIds.includes(edital.id)),
+    [editais, selectedEditalIds],
+  );
+
+  const handleToggleEdital = (editalId) => {
+    setSelectedEditalIds((prev) =>
+      prev.includes(editalId) ? prev.filter((id) => id !== editalId) : [...prev, editalId],
+    );
+  };
+
+  const handleApplyEditais = () => {
+    if (!activeProfileId) {
+      showToast('Selecione um perfil para aplicar editais.', 'warning');
+      return;
+    }
+
+    if (selectedEditais.length === 0) {
+      showToast('Selecione pelo menos um edital.', 'warning');
+      return;
+    }
+
+    const { subjects: mergedSubjects, syllabusItems: mergedItems } = mergeStudyContentWithExisting(
+      selectedEditais,
+      activeProfileId,
+      subjects,
+      syllabusItems,
+    );
+
+    if (mergedSubjects.length === 0) {
+      showToast('Os editais selecionados não possuem matérias ou tópicos cadastrados.', 'warning');
+      updateProfileEditais(activeProfileId, selectedEditalIds);
+      return;
+    }
+
+    const mergedSubjectIds = new Set(mergedSubjects.map((subject) => subject.id));
+    const mergedItemIds = new Set(mergedItems.map((item) => item.id));
+
+    const otherSubjects = subjects.filter((subject) => subject.profileId !== activeProfileId);
+    const retainedSubjects = subjects.filter(
+      (subject) => subject.profileId === activeProfileId && !mergedSubjectIds.has(subject.id),
+    );
+    const nextSubjects = [...otherSubjects, ...retainedSubjects, ...mergedSubjects];
+
+    const otherItems = syllabusItems.filter((item) => {
+      const subject = subjects.find((s) => s.id === item.subjectId);
+      return subject?.profileId !== activeProfileId;
+    });
+    const retainedItems = syllabusItems.filter((item) => {
+      if (mergedItemIds.has(item.id)) return false;
+      const subject = subjects.find((s) => s.id === item.subjectId);
+      return subject?.profileId === activeProfileId;
+    });
+    const nextItems = [...otherItems, ...retainedItems, ...mergedItems];
+
+    setSubjects(nextSubjects);
+    setSyllabusItems(nextItems);
+    saveToLocalStorage('subjects', nextSubjects);
+    saveToLocalStorage('syllabusItems', nextItems);
+    updateProfileEditais(activeProfileId, selectedEditalIds);
+    showToast('Editais aplicados ao perfil!', 'success');
   };
 
   return (
@@ -127,6 +208,74 @@ export const Settings = () => {
       </section>
 
       {/* Data Management */}
+      <section className="bg-slate-900 border border-slate-800 rounded-2xl p-6">
+        <h2 className="text-xl font-bold text-white mb-2">Editais Globais</h2>
+        <p className="text-sm text-slate-400 mb-6">
+          Selecione um ou mais editais globais para mesclar matérias e tópicos no perfil ativo.
+        </p>
+
+        {editais.length === 0 ? (
+          <p className="text-sm text-slate-500">Nenhum edital global disponível.</p>
+        ) : (
+          <div className="space-y-3">
+            {editais.map((edital) => (
+              <label
+                key={edital.id}
+                className="flex items-start gap-3 rounded-xl border border-slate-800 bg-slate-900/40 p-4 hover:border-slate-700 transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-800 text-blue-500 focus:ring-blue-500"
+                  checked={selectedEditalIds.includes(edital.id)}
+                  onChange={() => handleToggleEdital(edital.id)}
+                />
+                <div className="flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-semibold text-white">{edital.nome}</h3>
+                    {edital.isGlobal && (
+                      <span className="text-xs uppercase tracking-wide text-emerald-300 bg-emerald-500/10 border border-emerald-500/20 px-2 py-0.5 rounded-full">
+                        Global
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-slate-400">
+                    {edital.concurso || 'Concurso não informado'}
+                  </p>
+                  <p className="text-xs text-slate-500 mt-1">
+                    {edital.itensEdital?.length || 0} tópico(s) · {edital.materias?.length || 0} matéria(s)
+                  </p>
+                </div>
+              </label>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          <button
+            className="btn btn-primary"
+            onClick={handleApplyEditais}
+            disabled={selectedEditalIds.length === 0}
+          >
+            <Layers size={18} />
+            Aplicar editais ao perfil ativo
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={() => setIsComparisonOpen(true)}
+            disabled={selectedEditalIds.length < 2}
+          >
+            Comparar editais
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={() => setSelectedEditalIds([])}
+            disabled={selectedEditalIds.length === 0}
+          >
+            Limpar seleção
+          </button>
+        </div>
+      </section>
+
       <section className="bg-slate-900 border border-slate-800 rounded-2xl p-6">
         <h2 className="text-xl font-bold text-white mb-6">Gerenciamento de Dados</h2>
 
@@ -188,6 +337,12 @@ export const Settings = () => {
         onConfirm={confirmationDialog.onConfirm}
         onCancel={() => setConfirmationDialog(prev => ({ ...prev, isOpen: false }))}
         isDanger={true}
+      />
+
+      <EditalComparisonModal
+        isOpen={isComparisonOpen}
+        onClose={() => setIsComparisonOpen(false)}
+        editais={selectedEditais}
       />
     </div>
   );

--- a/src/utils/editalComparison.js
+++ b/src/utils/editalComparison.js
@@ -1,0 +1,275 @@
+const STOPWORDS = new Set([
+  'de',
+  'da',
+  'do',
+  'das',
+  'dos',
+  'e',
+  'a',
+  'o',
+  'as',
+  'os',
+  'em',
+  'no',
+  'na',
+  'nos',
+  'nas',
+  'para',
+  'por',
+  'ao',
+  'aos',
+  'à',
+  'às'
+]);
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const normalizeStudyName = (value) => {
+  if (!value || typeof value !== 'string') return '';
+
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/^\s*\d+(?:\.\d+)*(?:[.)-])?\s*/, '')
+    .replace(/[–—:/;,-]/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((word) => !STOPWORDS.has(word))
+    .join(' ')
+    .trim();
+};
+
+const getEditalMateriaNames = (edital) =>
+  (Array.isArray(edital?.materias) ? edital.materias : [])
+    .map((materia) => (typeof materia === 'string' ? materia : materia?.nome))
+    .filter(Boolean);
+
+const getEditalTopicos = (edital) =>
+  (Array.isArray(edital?.itensEdital) ? edital.itensEdital : [])
+    .map((item) => (typeof item === 'string' ? item : item?.nome))
+    .filter(Boolean);
+
+const pickSubjectForTopic = (topic, subjects) => {
+  if (!topic || subjects.length === 0) return null;
+  const trimmed = topic.trim();
+  for (const subject of subjects) {
+    if (!subject?.name) continue;
+    const directMatch = new RegExp(`^\\s*${escapeRegExp(subject.name)}\\s*[:\-–—]`, 'i');
+    if (directMatch.test(trimmed)) return subject;
+  }
+
+  const normalizedTopic = normalizeStudyName(trimmed);
+  if (!normalizedTopic) return null;
+
+  return subjects.find((subject) => normalizedTopic.startsWith(subject.key)) || null;
+};
+
+const getOrCreateSubject = (subjectMap, subjectName) => {
+  const key = normalizeStudyName(subjectName);
+  if (!key) return null;
+  if (!subjectMap.has(key)) {
+    subjectMap.set(key, {
+      key,
+      name: subjectName,
+      sources: new Set(),
+      topics: new Map()
+    });
+  } else {
+    const existing = subjectMap.get(key);
+    if (existing && subjectName.length > existing.name.length) {
+      existing.name = subjectName;
+    }
+  }
+  return subjectMap.get(key);
+};
+
+const getOrCreateTopic = (topicMap, topicName) => {
+  const key = normalizeStudyName(topicName);
+  if (!key) return null;
+  if (!topicMap.has(key)) {
+    topicMap.set(key, {
+      key,
+      name: topicName,
+      sources: new Set()
+    });
+  } else {
+    const existing = topicMap.get(key);
+    if (existing && topicName.length > existing.name.length) {
+      existing.name = topicName;
+    }
+  }
+  return topicMap.get(key);
+};
+
+export const mergeEditais = (editais) => {
+  const subjectMap = new Map();
+  const totalEditais = editais.length;
+
+  editais.forEach((edital) => {
+    const editalId = edital?.id || edital?.nome || Math.random().toString(36);
+    const materias = getEditalMateriaNames(edital);
+    const subjects = materias
+      .map((name) => ({ name, key: normalizeStudyName(name) }))
+      .filter((subject) => subject.key);
+
+    if (subjects.length === 0 && getEditalTopicos(edital).length > 0) {
+      subjects.push({ name: 'Tópicos Gerais', key: normalizeStudyName('Tópicos Gerais') });
+    }
+
+    subjects.forEach((subject) => {
+      const entry = getOrCreateSubject(subjectMap, subject.name);
+      if (entry) entry.sources.add(editalId);
+    });
+
+    const topics = getEditalTopicos(edital);
+    topics.forEach((topic) => {
+      const subject = pickSubjectForTopic(topic, subjects);
+      const subjectName = subject?.name || 'Tópicos Gerais';
+      const subjectEntry = getOrCreateSubject(subjectMap, subjectName);
+      if (!subjectEntry) return;
+      subjectEntry.sources.add(editalId);
+
+      const topicEntry = getOrCreateTopic(subjectEntry.topics, topic);
+      if (topicEntry) topicEntry.sources.add(editalId);
+    });
+  });
+
+  const mergedSubjects = Array.from(subjectMap.values()).map((subject) => ({
+    key: subject.key,
+    name: subject.name,
+    count: subject.sources.size,
+    totalEditais,
+    topics: Array.from(subject.topics.values()).map((topic) => ({
+      key: topic.key,
+      name: topic.name,
+      count: topic.sources.size,
+      totalEditais
+    }))
+  }));
+
+  mergedSubjects.sort((a, b) => a.name.localeCompare(b.name));
+  mergedSubjects.forEach((subject) => {
+    subject.topics.sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  return {
+    totalEditais,
+    subjects: mergedSubjects
+  };
+};
+
+export const buildStudyContentFromEditais = (editais, profileId) => {
+  const merged = mergeEditais(editais);
+  const subjects = [];
+  const syllabusItems = [];
+  const createdAt = new Date().toISOString();
+  let seed = Date.now();
+
+  merged.subjects.forEach((subject, subjectIndex) => {
+    const subjectId = `${profileId}-${seed + subjectIndex}`;
+    subjects.push({
+      id: subjectId,
+      profileId,
+      name: subject.name,
+      description: '',
+      color: '#3b82f6',
+      targetHours: 0,
+      normalizedKey: subject.key,
+      createdAt
+    });
+
+    subject.topics.forEach((topic, topicIndex) => {
+      syllabusItems.push({
+        id: `${subjectId}-${topicIndex}-${seed}`,
+        subjectId,
+        name: topic.name,
+        normalizedKey: topic.key,
+        isStudied: false,
+        createdAt
+      });
+    });
+
+    seed += 1;
+  });
+
+  return {
+    subjects,
+    syllabusItems
+  };
+};
+
+export const mergeStudyContentWithExisting = (
+  editais,
+  profileId,
+  existingSubjects,
+  existingSyllabusItems,
+) => {
+  const merged = mergeEditais(editais);
+  const subjects = [];
+  const syllabusItems = [];
+  const createdAt = new Date().toISOString();
+
+  const profileSubjects = (Array.isArray(existingSubjects) ? existingSubjects : []).filter(
+    (subject) => subject.profileId === profileId,
+  );
+  const subjectByKey = new Map();
+  profileSubjects.forEach((subject) => {
+    const key = subject.normalizedKey || normalizeStudyName(subject.name);
+    if (!key) return;
+    subjectByKey.set(key, subject);
+  });
+
+  const itemsBySubjectKey = new Map();
+  (Array.isArray(existingSyllabusItems) ? existingSyllabusItems : []).forEach((item) => {
+    const subject = profileSubjects.find((s) => s.id === item.subjectId);
+    const subjectKey = subject?.normalizedKey || normalizeStudyName(subject?.name || '');
+    if (!subjectKey) return;
+    const topicKey = item.normalizedKey || normalizeStudyName(item.name);
+    if (!topicKey) return;
+    if (!itemsBySubjectKey.has(subjectKey)) {
+      itemsBySubjectKey.set(subjectKey, new Map());
+    }
+    itemsBySubjectKey.get(subjectKey).set(topicKey, item);
+  });
+
+  merged.subjects.forEach((subject, subjectIndex) => {
+    const subjectKey = subject.key || normalizeStudyName(subject.name);
+    const existingSubject = subjectByKey.get(subjectKey);
+    const subjectId = existingSubject?.id || `${profileId}-${Date.now()}-${subjectIndex}`;
+
+    subjects.push({
+      id: subjectId,
+      profileId,
+      name: existingSubject?.name && existingSubject.name.length >= subject.name.length
+        ? existingSubject.name
+        : subject.name,
+      description: existingSubject?.description || '',
+      color: existingSubject?.color || '#3b82f6',
+      targetHours: existingSubject?.targetHours || 0,
+      normalizedKey: subjectKey,
+      createdAt: existingSubject?.createdAt || createdAt
+    });
+
+    const existingTopics = itemsBySubjectKey.get(subjectKey) || new Map();
+    subject.topics.forEach((topic, topicIndex) => {
+      const topicKey = topic.key || normalizeStudyName(topic.name);
+      if (!topicKey) return;
+      const existingItem = existingTopics.get(topicKey);
+      syllabusItems.push({
+        id: existingItem?.id || `${subjectId}-${topicIndex}-${Date.now()}`,
+        subjectId,
+        name: existingItem?.name && existingItem.name.length >= topic.name.length
+          ? existingItem.name
+          : topic.name,
+        normalizedKey: topicKey,
+        isStudied: existingItem?.isStudied || false,
+        nextReviewDate: existingItem?.nextReviewDate,
+        createdAt: existingItem?.createdAt || createdAt
+      });
+    });
+  });
+
+  return { subjects, syllabusItems };
+};

--- a/src/utils/editalManager.js
+++ b/src/utils/editalManager.js
@@ -1,5 +1,6 @@
 // Utilitários para gerenciar editais administrativos
 import { loadFromLocalStorage, saveToLocalStorage } from './localStorage';
+import { globalEditaisSeed } from '../data/globalEditais';
 
 export const loadAdminEditais = () => {
   try {
@@ -8,6 +9,22 @@ export const loadAdminEditais = () => {
   } catch (error) {
     console.error('Erro ao carregar editais:', error);
     return [];
+  }
+};
+
+export const seedGlobalEditais = () => {
+  try {
+    const existing = loadAdminEditais();
+    const existingIds = new Set(existing.map((edital) => edital.id));
+    const missingGlobals = globalEditaisSeed.filter((edital) => !existingIds.has(edital.id));
+
+    if (missingGlobals.length === 0) return false;
+
+    saveToLocalStorage('admin_editais', [...existing, ...missingGlobals]);
+    return true;
+  } catch (error) {
+    console.error('Erro ao carregar editais globais:', error);
+    return false;
   }
 };
 
@@ -39,7 +56,8 @@ export const getAvailableEditais = () => {
     banca: edital.banca,
     dataProva: edital.dataProva,
     materias: edital.materias || [],
-    itensEdital: edital.itensEdital || []
+    itensEdital: edital.itensEdital || [],
+    isGlobal: Boolean(edital.isGlobal)
   }));
 };
 


### PR DESCRIPTION
### Motivation

- Seed bundled editais (PDF placeholders + example JSON) into the app so users can choose them as "globais" without creating their own. 
- Allow opening/combining two or more editais and produce a merged verticalized table highlighting topics/matérias that are exclusive to any edital. 
- Preserve user progress when switching or overlaying editais by matching similar matéria/topic names written slightly differently. 
- Provide a lightweight normalization/merge strategy to map near-duplicate names and reduce manual reconciliation.

### Description

- Added a global seed file `src/data/globalEditais.js` and a seeder `seedGlobalEditais()` in `src/utils/editalManager.js` and exposed `getAvailableEditais()` for the UI. 
- Implemented normalization and merge utilities in `src/utils/editalComparison.js` (`normalizeStudyName`, `mergeEditais`, `mergeStudyContentWithExisting`) to align matérias and tópicos across editais. 
- Added UI to `Settings` (`src/pages/Settings.jsx`) to list/select global editais, apply merges into the active profile, and open a visual comparison modal implemented in `src/components/modals/EditalComparisonModal.jsx`. 
- Kept syllabus/subject items keyed for matching by storing `normalizedKey` when creating/updating items in `SyllabusModal` and propagating normalized keys in `useStudyData` so existing progress is reused where possible. 

### Testing

- Started the dev server with `npm run dev` which reported Vite ready (server running). 
- Verified HTTP reachability with `curl -I http://127.0.0.1:4173/` which returned `200 OK`. 
- Attempted an automated Playwright screenshot of `/settings` which failed with `net::ERR_CONNECTION_REFUSED` during the run, indicating a transient connection timing issue. 
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f4781830832d882e551a2459a87f)